### PR TITLE
fix: .env run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     // Actuator (Prometheus 연동)
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'me.paulschwarz:springboot4-dotenv:5.1.0'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/sportsify/member/presentation/controller/OAuthCallbackController.java
+++ b/src/main/java/com/sportsify/member/presentation/controller/OAuthCallbackController.java
@@ -1,0 +1,19 @@
+package com.sportsify.member.presentation.controller;
+
+import com.sportsify.member.presentation.dto.OAuthCallbackResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class OAuthCallbackController {
+
+    @GetMapping("/oauth2/callback")
+    public ResponseEntity<OAuthCallbackResponse> oauthCallback(
+            @RequestParam String accessToken,
+            @RequestParam String refreshToken
+    ) {
+        return ResponseEntity.ok(new OAuthCallbackResponse(accessToken, refreshToken));
+    }
+}

--- a/src/main/java/com/sportsify/member/presentation/dto/OAuthCallbackResponse.java
+++ b/src/main/java/com/sportsify/member/presentation/dto/OAuthCallbackResponse.java
@@ -1,0 +1,7 @@
+package com.sportsify.member.presentation.dto;
+
+public record OAuthCallbackResponse(
+        String accessToken,
+        String refreshToken
+) {
+}


### PR DESCRIPTION
# 버그 사유
- .env 파일 연결 실패

# 로그인 하는 방법
- 터미널에서 실행
    - ./gradlew bootRun 실행
    - 포트 종료 ✗ kill -9 $(lsof -t -i:8080)
-  EnvFile 플러그인 설치
    -  Settings (⌘,) → Plugins → Marketplace → "EnvFile" 검색 → Install → IDE 재시작
- Run Configuration에 .env 파일 연결
    -  Run → Edit Configurations → 앱 선택
        → "EnvFile" 탭 → "Enable EnvFile" 체크

# 로그인 경로
- http://localhost:8080/oauth2/authorization/kakao
- http://localhost:8080/oauth2/authorization/google