### PR TITLE
Hotfix: resolve local build/test failures and docker environment issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build
-        run: ./gradlew build -x test --no-daemon
+        run: ./gradlew build
 
 # CD는 인프라 구성 완료 후 추가 예정
 # deploy job: main 브랜치 push 시 EC2-1 Blue/Green 배포

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,8 +1,21 @@
+# 로컬 개발용 인프라 (postgres + redis)
+# 실행:  docker compose -f docker-compose.local.yml up -d
+# 종료:  docker compose -f docker-compose.local.yml down
+#
+# [postgres 스키마 초기화]
+# 1) 볼륨 포함 전체 삭제 후 재기동 (Flyway가 마이그레이션 재실행)
+#    docker compose -f docker-compose.local.yml down -v
+#    docker compose -f docker-compose.local.yml up -d
+#
+# 2) DB만 DROP & CREATE 후 재기동
+#    docker exec -it sportsify-postgres psql -U sportsify -c "DROP DATABASE sportsify;"
+#    docker exec -it sportsify-postgres psql -U sportsify -c "CREATE DATABASE sportsify;"
+
 services:
   postgres:
     image: postgres:18
     container_name: sportsify-postgres
-    env_file: .env.local
+    env_file: .env
     environment:
       POSTGRES_DB: ${DB_NAME:-sportsify}
       POSTGRES_USER: ${DB_USERNAME:-sportsify}
@@ -11,15 +24,22 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME:-sportsify}"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
 
   redis:
     image: redis:8-alpine
     container_name: sportsify-redis
+    # redis.conf 공식 기본값 기준 (https://raw.githubusercontent.com/redis/redis/8.0/redis.conf)
+    # M2 Air 로컬 개발 기준: 영속성 비활성화, 메모리 상한 256m, LRU 축출
+    command: >
+      redis-server
+      --save ""
+      --appendonly no
+      --maxmemory 256mb
+      --maxmemory-policy allkeys-lru
+      --hz 10
+      --loglevel warning
+      --databases 1
+      --tcp-keepalive 300
     ports:
       - "6379:6379"
     volumes:
@@ -30,34 +50,6 @@ services:
       timeout: 3s
       retries: 5
 
-  prometheus:
-    image: prom/prometheus:latest
-    container_name: sportsify-prometheus
-    ports:
-      - "9090:9090"
-    volumes:
-      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - prometheus_data:/prometheus
-    command:
-      - "--config.file=/etc/prometheus/prometheus.yml"
-
-  grafana:
-    image: grafana/grafana:latest
-    container_name: sportsify-grafana
-    ports:
-      - "3001:3000"
-    environment:
-      GF_SECURITY_ADMIN_USER: admin
-      GF_SECURITY_ADMIN_PASSWORD: admin
-    volumes:
-      - grafana_data:/var/lib/grafana
-      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
-      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
-    depends_on:
-      - prometheus
-
 volumes:
   postgres_data:
   redis_data:
-  prometheus_data:
-  grafana_data:

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,54 @@
+# 로컬 모니터링 (선택적): Prometheus + Grafana
+# 평소에는 끄고, 성능 분석 필요 시에만 기동
+# 실행: docker compose -f docker-compose.monitoring.yml up -d
+# 종료: docker compose -f docker-compose.monitoring.yml down
+
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: sportsify-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.retention.time=3d"
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256M
+        reservations:
+          cpus: "0.1"
+          memory: 128M
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: sportsify-grafana
+    ports:
+      - "3001:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_ANALYTICS_REPORTING_ENABLED: "false"
+      GF_ANALYTICS_CHECK_FOR_UPDATES: "false"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - prometheus
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256M
+        reservations:
+          cpus: "0.1"
+          memory: 128M
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -93,6 +93,11 @@ mqtt:
   username: ""
   password: ""
 
+toss:
+  payments:
+    secret-key: ${TOSS_SECRET_KEY:test_sk_local_dummy}
+    confirm-url: https://api.tosspayments.com/v1/payments/confirm
+
 logging:
   level:
     com.sportsify: DEBUG

--- a/src/main/resources/db/migration/V1__init_schema.sql
+++ b/src/main/resources/db/migration/V1__init_schema.sql
@@ -214,26 +214,25 @@ CREATE INDEX idx_tickets_status ON tickets (member_id, status);
 CREATE TABLE payments
 (
     id              BIGSERIAL PRIMARY KEY,
-    order_id        BIGINT    NOT NULL,
-    member_id       BIGINT,
-    payment_key     VARCHAR(200), -- PG사 거래 ID
-    idempotency_key VARCHAR(100), -- 중복 결제 방지 키
-    method          VARCHAR(30),  -- CARD | KAKAO_PAY | TOSS_PAY
-    total_amount    INT,
-    discount_amount INT       NOT NULL DEFAULT 0,
-    final_amount    INT,
-    status          VARCHAR(30),  -- PENDING | COMPLETED | REFUNDED | FAILED | CANCELLED
-    requested_at    TIMESTAMP,
-    approved_at     TIMESTAMP,
-    failed_at       TIMESTAMP,
-    created_at      TIMESTAMP NOT NULL,
-    updated_at      TIMESTAMP,
-    CONSTRAINT fk_payment_order FOREIGN KEY (order_id) REFERENCES orders (id),
-    CONSTRAINT fk_payment_member FOREIGN KEY (member_id) REFERENCES members (id),
-    CONSTRAINT uq_idempotency UNIQUE (idempotency_key)
+    user_id         BIGINT        NOT NULL,
+    match_id        BIGINT        NOT NULL,
+    seat_id         BIGINT        NOT NULL,
+    order_id        VARCHAR(50)   NOT NULL UNIQUE,
+    payment_key     VARCHAR(100)  UNIQUE,
+    idempotency_key VARCHAR(100)  NOT NULL UNIQUE,
+
+    amount          BIGINT        NOT NULL,
+    payment_method  VARCHAR(20)   NOT NULL,
+    status          VARCHAR(20)   NOT NULL,
+    requested_at    TIMESTAMP     NOT NULL,
+    approved_at     TIMESTAMPTZ,
+    canceled_at     TIMESTAMP,
+    cancel_reason   VARCHAR(255),
+    created_at      TIMESTAMP     NOT NULL,
+    updated_at      TIMESTAMP     NOT NULL
 );
 
-CREATE INDEX idx_payments_member ON payments (member_id);
+CREATE INDEX idx_payments_user ON payments (user_id);
 CREATE INDEX idx_payments_status ON payments (status);
 
 -- 환불
@@ -365,12 +364,15 @@ CREATE TABLE notification_events
     id           BIGSERIAL PRIMARY KEY,
     event_type   VARCHAR(50) NOT NULL,                   -- TICKET_OPEN | GAME_START | PAYMENT_COMPLETED | CHAT_MENTION
     payload      JSONB,
-    status       VARCHAR(20) NOT NULL DEFAULT 'PENDING', -- PENDING | PUBLISHED | FAILED
+    status       VARCHAR(20) NOT NULL DEFAULT 'PENDING', -- PENDING | PROCESSING | PUBLISHED | FAILED | CANCELLED
     created_at   TIMESTAMP   NOT NULL,
-    published_at TIMESTAMP
+    published_at TIMESTAMP,
+    scheduled_at TIMESTAMP NULL                          -- 예약 발송 시각 (null = 즉시 발송)
 );
 
 CREATE INDEX idx_ne_status ON notification_events (status, created_at);
+CREATE INDEX idx_ne_scheduled ON notification_events (status, scheduled_at)
+    WHERE scheduled_at IS NOT NULL;
 
 -- 사용자 인박스 알림
 CREATE TABLE notifications

--- a/src/test/java/com/sportsify/config/TestContainersConfig.java
+++ b/src/test/java/com/sportsify/config/TestContainersConfig.java
@@ -13,8 +13,9 @@ public class TestContainersConfig {
     @Bean
     @ServiceConnection
     public PostgreSQLContainer postgresContainer() {
-        return new PostgreSQLContainer(DockerImageName.parse("postgres:18-alpine"))
-                .withDatabaseName("sportsify");
+        return new PostgreSQLContainer(DockerImageName.parse("postgres:18"))
+                .withDatabaseName("sportsify")
+                .withReuse(true);
     }
 
     @Bean

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -57,6 +57,8 @@ jwt:
 app:
   oauth2:
     redirect-uri: http://localhost:3000/oauth2/callback
+  cors:
+    allowed-origins: http://localhost:3000
 
 mqtt:
   enabled: false
@@ -64,3 +66,8 @@ mqtt:
   client-id: sportsify-test
   username: ""
   password: ""
+
+toss:
+  payments:
+    secret-key: test-toss-secret-key
+    confirm-url: https://api.tosspayments.com/v1/payments/confirm


### PR DESCRIPTION
# Related Issues                                                                                              
                                                                                                                
  -
                                                                                                                
  ## 작업 리스트                                                                                                
   
  - [x] docker-compose { local, monitoring } 파일 분리 
  - [x] CI 빌드 수정 
  - [x] 테스트 컨테이너 이미지 및 재사용 설정 수정                                                              
  - [x] 로컬/테스트 환경 toss payments 설정 누락 추가                                                                         
                                                                                                                
  ## 작업 내용                                                                                                  
                                                                                                                
  - `docker-compose.local.yml`: prometheus/grafana를 `docker-compose.monitoring.yml`로 분리, PostgreSQL 18 볼륨 
  경로 수정, redis 로컬 최적화 설정 추가                    
  - `ci.yml`: `-x test` 제거로 CI에서 전체 테스트 실행, `--no-daemon` 제거                                      
  - `TestContainersConfig`: `postgres:18-alpine` → `postgres:18` (로컬 이미지 불일치로 인한 pull 지연 해소),    
  - `application-test.yml`: 중복 `app:` 키 병합, cors/toss 누락 설정 추가                                       
  - `V1__init_schema.sql`: payments 테이블을 Payment 엔티티 구조에 맞게 재정의, notification_events에           
  scheduled_at 컬럼·인덱스 추가       

  ## 참고사항

  - V1 스키마 변경으로 로컬 DB 초기화 필요: `docker compose -f docker-compose.local.yml down -v && up -d`
  
  - 도커 전체 초기화 
  1) docker stop $(docker ps -aq)
  2) docker rm $(docker ps -aq)
  3) docker volume prune -a
  4) docker image prune -a -f
  
  -- my_api 같은 이전 도커 제거 --  
  
  5)  docker compose -f docker-compose.local.yml up -d
  
  - 모니터링이 필요한 경우 `docker compose -f docker-compose.monitoring.yml up -d` 별도 실행