### PR TITLE
feat: add scheduled notification dispatch and streaming infrastructure

### DIFF
--- a/docs/db-migration-convention.md
+++ b/docs/db-migration-convention.md
@@ -1,0 +1,37 @@
+# DB Migration Convention
+
+## 파일 네이밍 규칙
+
+```
+V{number}__{domain}-schema.sql
+```
+
+| 요소 | 설명 | 예시 |
+|------|------|------|
+| `V{number}` | Flyway 버전 번호 (단조 증가) | `V2`, `V3` |
+| `__` | Flyway 구분자 (언더스코어 2개) | |
+| `{domain}-schema` | 변경 대상 도메인 + `schema` 고정 접미사 | `notification-schema` |
+
+### 예시
+
+```
+V1__init_schema.sql           ← 초기 전체 스키마 (기존)
+V2__notification-schema.sql   ← 알림 도메인 컬럼/인덱스 추가
+V3__payment-schema.sql        ← 결제 도메인 변경
+```
+
+## 원칙
+
+- **V1은 수정하지 않는다.** 이미 배포된 버전이므로 Flyway 체크섬 충돌 발생.
+- 스키마 변경은 항상 새 버전 파일로 추가한다.
+- 한 파일에는 한 도메인의 변경만 담는다.
+- `DROP`, `TRUNCATE` 등 비가역적 DDL은 팀 리뷰 후 적용한다.
+
+## 테스트 컨테이너
+
+- 이미지: `postgres:16-alpine` (`withReuse(true)`)
+- V1 이후 새 마이그레이션 파일이 추가되면 컨테이너를 재사용하므로 자동 적용됨.
+- V1을 수정한 경우에만 로컬 컨테이너를 수동 삭제해야 한다:
+  ```bash
+  docker ps -a | grep postgres | awk '{print $1}' | xargs docker rm -f
+  ```

--- a/src/main/java/com/sportsify/common/exception/ErrorCode.java
+++ b/src/main/java/com/sportsify/common/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     // 회원 / 인증
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "존재하지 않는 회원입니다."),
     NICKNAME_DUPLICATE(HttpStatus.CONFLICT, "NICKNAME_DUPLICATE", "이미 사용 중인 닉네임입니다."),
+    MEMBER_WITHDRAWN(HttpStatus.FORBIDDEN, "MEMBER_WITHDRAWN", "탈퇴한 회원입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_REFRESH_TOKEN", "유효하지 않거나 만료된 리프레시 토큰입니다."),
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM_NOT_FOUND", "존재하지 않는 팀입니다."),
     FAVORITE_TEAM_ALREADY_EXISTS(HttpStatus.CONFLICT, "FAVORITE_TEAM_ALREADY_EXISTS", "이미 등록된 선호 팀입니다."),

--- a/src/main/java/com/sportsify/common/notification/NotificationEventPublisher.java
+++ b/src/main/java/com/sportsify/common/notification/NotificationEventPublisher.java
@@ -2,6 +2,19 @@ package com.sportsify.common.notification;
 
 import com.sportsify.common.notification.payload.NotificationPayload;
 
+/**
+ * 알림 이벤트 발행 인터페이스.
+ *
+ * <p>eventType과 payload는 반드시 아래 쌍으로 사용해야 합니다.
+ * 잘못된 조합은 런타임 파싱 실패로 이어집니다.
+ *
+ * <pre>
+ * TICKET_OPEN       → TicketOpenPayload   (saleStartAt 있으면 예약 발송, 없으면 즉시)
+ * GAME_START        → GameStartPayload    (gameStartAt 30분 전 예약 발송, 없으면 즉시)
+ * PAYMENT_COMPLETED → PaymentCompletedPayload  (즉시 발송)
+ * CHAT_MENTION      → ChatMentionPayload        (즉시 발송)
+ * </pre>
+ */
 public interface NotificationEventPublisher {
 
     void publish(NotificationEventType eventType, NotificationPayload payload);

--- a/src/main/java/com/sportsify/common/notification/NotificationEventType.java
+++ b/src/main/java/com/sportsify/common/notification/NotificationEventType.java
@@ -3,13 +3,24 @@ package com.sportsify.common.notification;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Getter
 @RequiredArgsConstructor
 public enum NotificationEventType {
-    TICKET_OPEN("ticket.opened"),
-    GAME_START("game.starting"),
-    PAYMENT_COMPLETED("payment.completed"),
-    CHAT_MENTION("chat.mentioned");
+    TICKET_OPEN("ticket.opened", true, false),
+    GAME_START("game.starting", true, false),
+    PAYMENT_COMPLETED("payment.completed", false, true),
+    CHAT_MENTION("chat.mentioned", false, true);
 
     private final String streamKey;
+    private final boolean scheduled;
+    private final boolean singleTarget;
+
+    public static Map<String, NotificationEventType> streamKeyMap() {
+        return Arrays.stream(values())
+                .collect(Collectors.toMap(NotificationEventType::getStreamKey, e -> e));
+    }
 }

--- a/src/main/java/com/sportsify/common/notification/payload/TicketOpenPayload.java
+++ b/src/main/java/com/sportsify/common/notification/payload/TicketOpenPayload.java
@@ -6,6 +6,6 @@ public record TicketOpenPayload(
         Long gameId,
         String homeTeam,
         String awayTeam,
-        LocalDateTime salesStartAt,
+        LocalDateTime saleStartAt,
         LocalDateTime gameStartAt
 ) implements NotificationPayload {}

--- a/src/main/java/com/sportsify/infrastructure/config/JpaAuditingConfig.java
+++ b/src/main/java/com/sportsify/infrastructure/config/JpaAuditingConfig.java
@@ -1,9 +1,26 @@
 package com.sportsify.infrastructure.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
 @Configuration
-@EnableJpaAuditing
+@EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
 public class JpaAuditingConfig {
+
+    @Bean
+    public AtomicReference<Clock> clockReference() {
+        return new AtomicReference<>(Clock.systemDefaultZone());
+    }
+
+    @Bean
+    public DateTimeProvider auditingDateTimeProvider(AtomicReference<Clock> clockReference) {
+        return () -> Optional.of(LocalDateTime.now(clockReference.get()));
+    }
 }

--- a/src/main/java/com/sportsify/infrastructure/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/sportsify/infrastructure/security/CustomOAuth2UserService.java
@@ -1,7 +1,8 @@
 package com.sportsify.infrastructure.security;
 
+import com.sportsify.common.exception.BusinessException;
+import com.sportsify.common.exception.ErrorCode;
 import com.sportsify.member.domain.model.Member;
-import com.sportsify.member.domain.model.OAuthProvider;
 import com.sportsify.member.infrastructure.repository.MemberJpaRepository;
 import com.sportsify.notification.domain.model.NotificationSetting;
 import com.sportsify.notification.domain.repository.NotificationSettingRepository;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -32,16 +34,20 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         OAuth2UserInfo info = OAuth2UserInfo.of(registrationId, oAuth2User.getAttributes());
 
-        boolean[] isNew = {false};
-        Member member = memberRepository.findByProviderAndProviderId(info.provider(), info.providerId())
-                .orElseGet(() -> {
-                    isNew[0] = true;
-                    return memberRepository.save(
-                            Member.create(info.email(), info.nickname(), info.provider(), info.providerId())
-                    );
-                });
-        if (isNew[0]) {
+        Optional<Member> existing = memberRepository.findByProviderAndProviderId(info.provider(), info.providerId());
+
+        Member member;
+        if (existing.isEmpty()) {
+            member = memberRepository.save(
+                    Member.create(info.email(), info.nickname(), info.provider(), info.providerId())
+            );
             notificationSettingRepository.save(NotificationSetting.createDefault(member.getId()));
+        } else {
+            member = existing.get();
+        }
+
+        if (member.isWithdrawn()) {
+            throw new BusinessException(ErrorCode.MEMBER_WITHDRAWN);
         }
 
         member.updateLastLoginAt();

--- a/src/main/java/com/sportsify/notification/application/service/NotificationDispatcher.java
+++ b/src/main/java/com/sportsify/notification/application/service/NotificationDispatcher.java
@@ -2,16 +2,14 @@ package com.sportsify.notification.application.service;
 
 import com.sportsify.notification.application.port.SseNotificationPort;
 import com.sportsify.notification.application.sender.NotificationSender;
-import com.sportsify.notification.domain.model.Notification;
-import com.sportsify.notification.domain.model.NotificationChannel;
-import com.sportsify.notification.domain.model.NotificationChannelType;
-import com.sportsify.notification.domain.model.NotificationEvent;
-import com.sportsify.notification.domain.model.NotificationHistory;
+import com.sportsify.notification.domain.model.*;
 import com.sportsify.notification.domain.repository.NotificationChannelRepository;
 import com.sportsify.notification.domain.repository.NotificationHistoryRepository;
 import com.sportsify.notification.domain.repository.NotificationRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.List;
 import java.util.Map;
@@ -51,7 +49,9 @@ public class NotificationDispatcher {
             return false;
         }
         Notification notification = notificationRepository.save(Notification.create(memberId, event.getId()));
-        sseNotificationPort.send(memberId, event.getEventType().name());
+
+        String eventTypeName = event.getEventType().name();
+        scheduleSse(memberId, eventTypeName);
 
         List<NotificationChannel> channels = channelRepository.findByMemberIdAndEnabledTrue(memberId);
         boolean anyFailed = false;
@@ -61,6 +61,19 @@ public class NotificationDispatcher {
             }
         }
         return anyFailed;
+    }
+
+    private void scheduleSse(Long memberId, String eventTypeName) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            sseNotificationPort.send(memberId, eventTypeName);
+            return;
+        }
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                sseNotificationPort.send(memberId, eventTypeName);
+            }
+        });
     }
 
     private boolean sendWithRetry(Long notificationId, NotificationChannel channel, String subject, String body) {

--- a/src/main/java/com/sportsify/notification/application/service/NotificationEventProcessor.java
+++ b/src/main/java/com/sportsify/notification/application/service/NotificationEventProcessor.java
@@ -16,6 +16,14 @@ public class NotificationEventProcessor {
 
     public void process(NotificationEventType eventType, String payload) {
         NotificationEvent event = statusService.saveEvent(eventType, payload);
+        if (event.isScheduled()) {
+            log.info("예약 알림 보류 eventId={} scheduledAt={}", event.getId(), event.getScheduledAt());
+            return;
+        }
+        fanout(event, eventType, payload);
+    }
+
+    public void fanout(NotificationEvent event, NotificationEventType eventType, String payload) {
         boolean anyFailed = true;
         try {
             anyFailed = fanoutService.fanout(event, eventType, payload);

--- a/src/main/java/com/sportsify/notification/application/service/NotificationEventStatusService.java
+++ b/src/main/java/com/sportsify/notification/application/service/NotificationEventStatusService.java
@@ -6,8 +6,12 @@ import com.sportsify.notification.domain.repository.NotificationEventRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -15,23 +19,54 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationEventStatusService {
 
     private final NotificationEventRepository eventRepository;
+    private final NotificationPayloadParser payloadParser;
 
     @Transactional
     public NotificationEvent saveEvent(NotificationEventType eventType, String payload) {
+        if (eventType.isScheduled()) {
+            Optional<LocalDateTime> scheduledAt = payloadParser.extractScheduledAt(payload, eventType);
+            if (scheduledAt.isPresent()) {
+                return eventRepository.save(NotificationEvent.createScheduled(eventType, payload, scheduledAt.get()));
+            }
+        }
         return eventRepository.save(NotificationEvent.create(eventType, payload));
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
+    public NotificationEvent saveEventWithStreamMessageId(NotificationEventType eventType, String payload, String streamMessageId) {
+        return eventRepository.findByStreamMessageId(streamMessageId)
+                .orElseGet(() -> {
+                    NotificationEvent event = buildEvent(eventType, payload);
+                    event.assignStreamMessageId(streamMessageId);
+                    return eventRepository.save(event);
+                });
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.READ_COMMITTED)
     public void markEventStatus(Long eventId, boolean anyFailed) {
         eventRepository.findById(eventId).ifPresentOrElse(
-                event -> {
-                    if (anyFailed) {
-                        event.markFailed();
-                    } else {
-                        event.markPublished();
-                    }
-                },
+                event -> applyStatus(event, anyFailed),
                 () -> log.warn("마킹할 이벤트를 찾을 수 없음 eventId={}", eventId)
         );
+    }
+
+    private NotificationEvent buildEvent(NotificationEventType eventType, String payload) {
+        if (eventType.isScheduled()) {
+            Optional<LocalDateTime> scheduledAt = payloadParser.extractScheduledAt(payload, eventType);
+            if (scheduledAt.isPresent()) {
+                return NotificationEvent.createScheduled(eventType, payload, scheduledAt.get());
+            }
+        }
+        return NotificationEvent.create(eventType, payload);
+    }
+
+    private void applyStatus(NotificationEvent event, boolean anyFailed) {
+        if (anyFailed) {
+            event.markFailed();
+            eventRepository.save(event);
+            return;
+        }
+        event.markPublished();
+        eventRepository.save(event);
     }
 }

--- a/src/main/java/com/sportsify/notification/application/service/NotificationFanoutService.java
+++ b/src/main/java/com/sportsify/notification/application/service/NotificationFanoutService.java
@@ -20,22 +20,18 @@ public class NotificationFanoutService {
 
     private final NotificationSettingRepository settingRepository;
     private final NotificationChunkService chunkService;
+    private final NotificationPayloadParser payloadParser;
 
     public boolean fanout(NotificationEvent event, NotificationEventType eventType, String payload) {
-        if (isSingleTarget(eventType)) {
+        if (eventType.isSingleTarget()) {
             return fanoutSingleTarget(event, eventType, payload);
         }
         return fanoutBroadcast(event, eventType, payload);
     }
 
-    private boolean isSingleTarget(NotificationEventType eventType) {
-        return eventType == NotificationEventType.CHAT_MENTION
-                || eventType == NotificationEventType.PAYMENT_COMPLETED;
-    }
-
     private boolean fanoutSingleTarget(NotificationEvent event, NotificationEventType eventType, String payload) {
         try {
-            Long memberId = NotificationPayloadParser.extractMemberId(payload, eventType.name());
+            Long memberId = payloadParser.extractMemberId(payload, eventType.name());
             return chunkService.processChunk(event, List.of(memberId), payload);
         } catch (Exception e) {
             log.error("{} payload에서 memberId 추출 실패", eventType.name(), e);

--- a/src/main/java/com/sportsify/notification/application/service/NotificationPayloadParser.java
+++ b/src/main/java/com/sportsify/notification/application/service/NotificationPayloadParser.java
@@ -1,15 +1,27 @@
 package com.sportsify.notification.application.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sportsify.common.notification.NotificationEventType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
-class NotificationPayloadParser {
+import java.time.LocalDateTime;
+import java.util.Optional;
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationPayloadParser {
 
-    static Long extractMemberId(String payload, String eventTypeName) {
+    private static final long GAME_START_OFFSET_MINUTES = 30;
+
+    private final ObjectMapper objectMapper;
+
+    public Long extractMemberId(String payload, String eventTypeName) {
         try {
-            JsonNode node = MAPPER.readTree(payload);
+            JsonNode node = objectMapper.readTree(payload);
             JsonNode memberIdNode = node.get("memberId");
             if (memberIdNode == null || memberIdNode.isNull() || !memberIdNode.isIntegralNumber()) {
                 throw new IllegalArgumentException("invalid memberId in " + eventTypeName + " payload");
@@ -20,5 +32,28 @@ class NotificationPayloadParser {
         } catch (Exception e) {
             throw new IllegalArgumentException("invalid memberId in " + eventTypeName + " payload", e);
         }
+    }
+
+    public Optional<LocalDateTime> extractScheduledAt(String payload, NotificationEventType eventType) {
+        try {
+            JsonNode node = objectMapper.readTree(payload);
+            return switch (eventType) {
+                case TICKET_OPEN -> parseDateTime(node, "saleStartAt");
+                case GAME_START -> parseDateTime(node, "gameStartAt")
+                        .map(t -> t.minusMinutes(GAME_START_OFFSET_MINUTES));
+                default -> Optional.empty();
+            };
+        } catch (Exception e) {
+            log.warn("scheduledAt 파싱 실패 eventType={} payload={}", eventType, payload, e);
+            return Optional.empty();
+        }
+    }
+
+    private Optional<LocalDateTime> parseDateTime(JsonNode node, String fieldName) {
+        JsonNode fieldNode = node.get(fieldName);
+        if (fieldNode == null || fieldNode.isNull()) {
+            return Optional.empty();
+        }
+        return Optional.of(LocalDateTime.parse(fieldNode.asText()));
     }
 }

--- a/src/main/java/com/sportsify/notification/application/service/NotificationSettingService.java
+++ b/src/main/java/com/sportsify/notification/application/service/NotificationSettingService.java
@@ -24,17 +24,17 @@ public class NotificationSettingService {
     private final NotificationSettingRepository settingRepository;
     private final NotificationChannelRepository channelRepository;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public NotificationSettingResult getSetting(Long memberId) {
         NotificationSetting setting = settingRepository.findByMemberId(memberId)
-                .orElseGet(() -> settingRepository.save(NotificationSetting.createDefault(memberId)));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_SETTING_NOT_FOUND));
         return NotificationSettingResult.from(setting);
     }
 
     @Transactional
     public NotificationSettingResult updateSetting(Long memberId, UpdateNotificationSettingCommand command) {
         NotificationSetting setting = settingRepository.findByMemberId(memberId)
-                .orElseGet(() -> settingRepository.save(NotificationSetting.createDefault(memberId)));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_SETTING_NOT_FOUND));
         setting.update(command.ticketOpenAlert(), command.gameStartAlert(), command.paymentAlert(), command.chatMentionAlert());
         return NotificationSettingResult.from(setting);
     }

--- a/src/main/java/com/sportsify/notification/application/service/ProcessingStuckRecoveryService.java
+++ b/src/main/java/com/sportsify/notification/application/service/ProcessingStuckRecoveryService.java
@@ -1,0 +1,32 @@
+package com.sportsify.notification.application.service;
+
+import com.sportsify.notification.domain.model.NotificationEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProcessingStuckRecoveryService {
+
+    private static final long STUCK_TIMEOUT_MINUTES = 10;
+    private static final long RECOVERY_INTERVAL_MS = STUCK_TIMEOUT_MINUTES * 60 * 1_000;
+
+    private final ScheduledEventClaimService claimService;
+
+    @Scheduled(fixedDelay = RECOVERY_INTERVAL_MS)
+    public void recoverStuckEvents() {
+        LocalDateTime stuckBefore = LocalDateTime.now().minusMinutes(STUCK_TIMEOUT_MINUTES);
+        List<NotificationEvent> stuck = claimService.claimStuckEvents(stuckBefore);
+        if (stuck.isEmpty()) {
+            return;
+        }
+        log.warn("PROCESSING stuck 이벤트 감지 count={} — PENDING으로 복구", stuck.size());
+        stuck.forEach(event -> log.warn("stuck 이벤트 복구 eventId={} updatedAt={}", event.getId(), event.getUpdatedAt()));
+    }
+}

--- a/src/main/java/com/sportsify/notification/application/service/ScheduledEventClaimService.java
+++ b/src/main/java/com/sportsify/notification/application/service/ScheduledEventClaimService.java
@@ -1,0 +1,40 @@
+package com.sportsify.notification.application.service;
+
+import com.sportsify.notification.domain.model.NotificationEvent;
+import com.sportsify.notification.domain.repository.NotificationEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduledEventClaimService {
+
+    private final NotificationEventRepository eventRepository;
+
+    // FOR UPDATE SKIP LOCKED는 READ_COMMITTED에서만 의도대로 동작
+    // REPEATABLE_READ 이상이면 스냅샷 기준으로 동작해 skip 의미가 달라짐
+    @Transactional(isolation = Isolation.READ_COMMITTED)
+    public List<NotificationEvent> claimDueEvents() {
+        List<NotificationEvent> events = eventRepository.findDueScheduledEventsForUpdate(LocalDateTime.now());
+        events.forEach(event -> {
+            event.markProcessing();
+            eventRepository.save(event);
+        });
+        return events;
+    }
+
+    @Transactional(isolation = Isolation.READ_COMMITTED)
+    public List<NotificationEvent> claimStuckEvents(LocalDateTime stuckBefore) {
+        List<NotificationEvent> events = eventRepository.findStuckProcessingEventsForUpdate(stuckBefore);
+        events.forEach(event -> {
+            event.markPending();
+            eventRepository.save(event);
+        });
+        return events;
+    }
+}

--- a/src/main/java/com/sportsify/notification/application/service/ScheduledNotificationProcessor.java
+++ b/src/main/java/com/sportsify/notification/application/service/ScheduledNotificationProcessor.java
@@ -1,0 +1,36 @@
+package com.sportsify.notification.application.service;
+
+import com.sportsify.notification.domain.model.NotificationEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ScheduledNotificationProcessor {
+
+    private final ScheduledEventClaimService claimService;
+    private final NotificationEventProcessor eventProcessor;
+
+    // 매 5분 단위 정각 실행 (0, 5, 10, 15 ... 분)
+    // saleStartAt이 과거 시각이면 다음 tick에 최대 5분 지연 발송됨 — 의도된 동작
+    @Scheduled(cron = "0 0/5 * * * *")
+    public void processDue() {
+        List<NotificationEvent> claimed = claimService.claimDueEvents();
+        if (claimed.isEmpty()) {
+            return;
+        }
+        log.info("예약 알림 처리 시작 count={}", claimed.size());
+        for (NotificationEvent event : claimed) {
+            try {
+                eventProcessor.fanout(event, event.getEventType(), event.getPayload());
+            } catch (Exception e) {
+                log.error("예약 알림 fanout 실패 eventId={}", event.getId(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/sportsify/notification/domain/model/NotificationChannel.java
+++ b/src/main/java/com/sportsify/notification/domain/model/NotificationChannel.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -41,6 +42,7 @@ public class NotificationChannel {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
@@ -61,6 +63,5 @@ public class NotificationChannel {
 
     public void toggle() {
         this.enabled = !this.enabled;
-        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/sportsify/notification/domain/model/NotificationEvent.java
+++ b/src/main/java/com/sportsify/notification/domain/model/NotificationEvent.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -42,11 +43,27 @@ public class NotificationEvent {
     @Column(name = "published_at")
     private LocalDateTime publishedAt;
 
+    @Column(name = "scheduled_at")
+    private LocalDateTime scheduledAt;
+
+    @Column(name = "stream_message_id", unique = true)
+    private String streamMessageId;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
     public static NotificationEvent create(NotificationEventType eventType, String payload) {
         NotificationEvent event = new NotificationEvent();
         event.eventType = eventType;
         event.payload = payload;
         event.status = NotificationEventStatus.PENDING;
+        return event;
+    }
+
+    public static NotificationEvent createScheduled(NotificationEventType eventType, String payload, LocalDateTime scheduledAt) {
+        NotificationEvent event = create(eventType, payload);
+        event.scheduledAt = scheduledAt;
         return event;
     }
 
@@ -56,6 +73,26 @@ public class NotificationEvent {
         return event;
     }
 
+    public void assignStreamMessageId(String streamMessageId) {
+        this.streamMessageId = streamMessageId;
+    }
+
+    public boolean isScheduled() {
+        return scheduledAt != null;
+    }
+
+    public boolean hasStreamMessageId() {
+        return streamMessageId != null;
+    }
+
+    public void markPending() {
+        this.status = NotificationEventStatus.PENDING;
+    }
+
+    public void markProcessing() {
+        this.status = NotificationEventStatus.PROCESSING;
+    }
+
     public void markPublished() {
         this.status = NotificationEventStatus.PUBLISHED;
         this.publishedAt = LocalDateTime.now();
@@ -63,5 +100,9 @@ public class NotificationEvent {
 
     public void markFailed() {
         this.status = NotificationEventStatus.FAILED;
+    }
+
+    public void markCancelled() {
+        this.status = NotificationEventStatus.CANCELLED;
     }
 }

--- a/src/main/java/com/sportsify/notification/domain/model/NotificationEventStatus.java
+++ b/src/main/java/com/sportsify/notification/domain/model/NotificationEventStatus.java
@@ -1,5 +1,5 @@
 package com.sportsify.notification.domain.model;
 
 public enum NotificationEventStatus {
-    PENDING, PUBLISHED, FAILED
+    PENDING, PROCESSING, PUBLISHED, FAILED, CANCELLED
 }

--- a/src/main/java/com/sportsify/notification/domain/model/NotificationHistory.java
+++ b/src/main/java/com/sportsify/notification/domain/model/NotificationHistory.java
@@ -43,7 +43,6 @@ public class NotificationHistory {
         history.notificationId = notificationId;
         history.channelType = channelType;
         history.status = NotificationSendStatus.SENT;
-        history.errorMessage = "";
         return history;
     }
 

--- a/src/main/java/com/sportsify/notification/domain/model/NotificationSetting.java
+++ b/src/main/java/com/sportsify/notification/domain/model/NotificationSetting.java
@@ -5,11 +5,14 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "notification_settings")
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NotificationSetting {
@@ -33,6 +36,7 @@ public class NotificationSetting {
     @Column(name = "chat_mention_alert", nullable = false)
     private boolean chatMentionAlert;
 
+    @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
@@ -51,7 +55,6 @@ public class NotificationSetting {
         this.gameStartAlert = gameStartAlert;
         this.paymentAlert = paymentAlert;
         this.chatMentionAlert = chatMentionAlert;
-        this.updatedAt = LocalDateTime.now();
     }
 
     public boolean isEnabledFor(NotificationEventType eventType) {

--- a/src/main/java/com/sportsify/notification/domain/repository/NotificationEventRepository.java
+++ b/src/main/java/com/sportsify/notification/domain/repository/NotificationEventRepository.java
@@ -1,11 +1,16 @@
 package com.sportsify.notification.domain.repository;
 
 import com.sportsify.notification.domain.model.NotificationEvent;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface NotificationEventRepository {
     NotificationEvent save(NotificationEvent event);
     Optional<NotificationEvent> findById(Long id);
+    Optional<NotificationEvent> findByStreamMessageId(String streamMessageId);
     List<NotificationEvent> findAllById(List<Long> ids);
+    List<NotificationEvent> findDueScheduledEventsForUpdate(LocalDateTime now);
+    List<NotificationEvent> findStuckProcessingEventsForUpdate(LocalDateTime updatedBefore);
 }

--- a/src/main/java/com/sportsify/notification/infrastructure/config/RedisStreamsConfig.java
+++ b/src/main/java/com/sportsify/notification/infrastructure/config/RedisStreamsConfig.java
@@ -22,6 +22,7 @@ public class RedisStreamsConfig {
 
     public static final String NOTIFICATION_GROUP = "notification-group";
     public static final int STREAM_MAX_LEN = 10_000;
+    private static final Duration POLL_TIMEOUT = Duration.ofSeconds(2);
 
     public static final List<String> STREAM_KEYS = Arrays.stream(NotificationEventType.values())
             .map(NotificationEventType::getStreamKey)
@@ -36,7 +37,7 @@ public class RedisStreamsConfig {
 
         var options = StreamMessageListenerContainer.StreamMessageListenerContainerOptions
                 .builder()
-                .pollTimeout(Duration.ofMillis(2000))
+                .pollTimeout(POLL_TIMEOUT)
                 .targetType(String.class)
                 .build();
 

--- a/src/main/java/com/sportsify/notification/infrastructure/consumer/NotificationStreamConsumer.java
+++ b/src/main/java/com/sportsify/notification/infrastructure/consumer/NotificationStreamConsumer.java
@@ -12,9 +12,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.stream.StreamMessageListenerContainer;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -22,8 +20,7 @@ import java.util.stream.Collectors;
 public class NotificationStreamConsumer {
 
     private static final Map<String, NotificationEventType> STREAM_TO_EVENT =
-            Arrays.stream(NotificationEventType.values())
-                    .collect(Collectors.toMap(NotificationEventType::getStreamKey, e -> e));
+            NotificationEventType.streamKeyMap();
 
     private final StreamMessageListenerContainer<String, ObjectRecord<String, String>> container;
     private final StringRedisTemplate redisTemplate;
@@ -49,6 +46,7 @@ public class NotificationStreamConsumer {
     private void handleMessage(String streamKey, NotificationEventType eventType, ObjectRecord<String, String> message) {
         try {
             processor.process(eventType, message.getValue());
+            // 예약 이벤트도 ACK — DB에 PENDING 상태로 저장됐으므로 Stream 재처리 불필요
             redisTemplate.opsForStream().acknowledge(streamKey, RedisStreamsConfig.NOTIFICATION_GROUP, message.getId());
             log.info("Stream ACK streamKey={} id={}", streamKey, message.getId());
         } catch (Exception e) {

--- a/src/main/java/com/sportsify/notification/infrastructure/consumer/NotificationStreamMaintenanceScheduler.java
+++ b/src/main/java/com/sportsify/notification/infrastructure/consumer/NotificationStreamMaintenanceScheduler.java
@@ -1,8 +1,11 @@
 package com.sportsify.notification.infrastructure.consumer;
 
 import com.sportsify.notification.application.service.NotificationEventProcessor;
+import com.sportsify.notification.application.service.NotificationEventStatusService;
 import com.sportsify.common.notification.NotificationEventType;
+import com.sportsify.notification.domain.model.NotificationEvent;
 import com.sportsify.notification.infrastructure.config.RedisStreamsConfig;
+import com.sportsify.notification.infrastructure.publisher.RedisStreamNotificationEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Range;
@@ -17,8 +20,6 @@ import org.springframework.stereotype.Component;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Slf4j
 @Component
@@ -29,19 +30,15 @@ public class NotificationStreamMaintenanceScheduler {
     private static final int PEL_BATCH_SIZE = 100;
 
     private final StringRedisTemplate redisTemplate;
-    private final NotificationEventProcessor processor;
+    private final NotificationEventProcessor eventProcessor;
+    private final NotificationEventStatusService statusService;
 
     private static final Map<String, NotificationEventType> STREAM_TO_EVENT =
-            Stream.of(NotificationEventType.values())
-                    .collect(Collectors.toMap(NotificationEventType::getStreamKey, e -> e));
+            NotificationEventType.streamKeyMap();
 
     @Scheduled(fixedDelay = 600_000)
     public void reclaimPendingMessages() {
-        for (Map.Entry<String, NotificationEventType> entry : STREAM_TO_EVENT.entrySet()) {
-            String streamKey = entry.getKey();
-            NotificationEventType eventType = entry.getValue();
-            reclaimForStream(streamKey, eventType);
-        }
+        STREAM_TO_EVENT.forEach(this::reclaimForStream);
     }
 
     @Scheduled(cron = "0 0 3 * * *")
@@ -82,17 +79,26 @@ public class NotificationStreamMaintenanceScheduler {
                             PEL_CLAIM_MIN_IDLE, ids);
 
             for (MapRecord<String, Object, Object> message : reclaimed) {
-                try {
-                    String payload = String.valueOf(message.getValue().values().iterator().next());
-                    processor.process(eventType, payload);
-                    redisTemplate.opsForStream().acknowledge(streamKey, RedisStreamsConfig.NOTIFICATION_GROUP, message.getId());
-                    log.info("PEL 재처리 완료 streamKey={} id={}", streamKey, message.getId());
-                } catch (Exception e) {
-                    log.error("PEL 재처리 실패 streamKey={} id={} error={}", streamKey, message.getId(), e.getMessage());
-                }
+                processReclaimedMessage(streamKey, eventType, message);
             }
         } catch (Exception e) {
             log.error("PEL 재처리 스케줄러 오류 streamKey={} error={}", streamKey, e.getMessage());
+        }
+    }
+
+    private void processReclaimedMessage(String streamKey, NotificationEventType eventType,
+                                         MapRecord<String, Object, Object> message) {
+        try {
+            String payload = String.valueOf(message.getValue().get(RedisStreamNotificationEventPublisher.PAYLOAD_KEY));
+            String streamMessageId = message.getId().getValue();
+            NotificationEvent event = statusService.saveEventWithStreamMessageId(eventType, payload, streamMessageId);
+            if (!event.isScheduled()) {
+                eventProcessor.fanout(event, eventType, payload);
+            }
+            redisTemplate.opsForStream().acknowledge(streamKey, RedisStreamsConfig.NOTIFICATION_GROUP, message.getId());
+            log.info("PEL 재처리 완료 streamKey={} id={}", streamKey, message.getId());
+        } catch (Exception e) {
+            log.error("PEL 재처리 실패 streamKey={} id={} error={}", streamKey, message.getId(), e.getMessage());
         }
     }
 }

--- a/src/main/java/com/sportsify/notification/infrastructure/publisher/RedisStreamNotificationEventPublisher.java
+++ b/src/main/java/com/sportsify/notification/infrastructure/publisher/RedisStreamNotificationEventPublisher.java
@@ -16,7 +16,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class RedisStreamNotificationEventPublisher implements NotificationEventPublisher {
 
-    private static final String PAYLOAD_KEY = "payload";
+    public static final String PAYLOAD_KEY = "payload";
 
     private final StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper;

--- a/src/main/java/com/sportsify/notification/infrastructure/repository/NotificationEventJpaRepository.java
+++ b/src/main/java/com/sportsify/notification/infrastructure/repository/NotificationEventJpaRepository.java
@@ -5,10 +5,20 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface NotificationEventJpaRepository extends JpaRepository<NotificationEvent, Long> {
 
-    @Query("SELECT e FROM NotificationEvent e WHERE e.id IN :ids")
-    List<NotificationEvent> findAllByIdIn(@Param("ids") List<Long> ids);
+    Optional<NotificationEvent> findByStreamMessageId(String streamMessageId);
+
+    @Query(value = "SELECT * FROM notification_events WHERE status = 'PENDING' AND scheduled_at <= :now FOR UPDATE SKIP LOCKED",
+            nativeQuery = true)
+    List<NotificationEvent> findDueScheduledEventsForUpdate(@Param("now") LocalDateTime now);
+
+    @Query(value = "SELECT * FROM notification_events WHERE status = 'PROCESSING' AND updated_at <= :updatedBefore FOR UPDATE SKIP LOCKED",
+            nativeQuery = true)
+    List<NotificationEvent> findStuckProcessingEventsForUpdate(@Param("updatedBefore") LocalDateTime updatedBefore);
+
 }

--- a/src/main/java/com/sportsify/notification/infrastructure/repository/NotificationEventRepositoryAdapter.java
+++ b/src/main/java/com/sportsify/notification/infrastructure/repository/NotificationEventRepositoryAdapter.java
@@ -4,6 +4,8 @@ import com.sportsify.notification.domain.model.NotificationEvent;
 import com.sportsify.notification.domain.repository.NotificationEventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,7 +25,22 @@ public class NotificationEventRepositoryAdapter implements NotificationEventRepo
     }
 
     @Override
+    public Optional<NotificationEvent> findByStreamMessageId(String streamMessageId) {
+        return jpaRepository.findByStreamMessageId(streamMessageId);
+    }
+
+    @Override
     public List<NotificationEvent> findAllById(List<Long> ids) {
-        return jpaRepository.findAllByIdIn(ids);
+        return jpaRepository.findAllById(ids);
+    }
+
+    @Override
+    public List<NotificationEvent> findDueScheduledEventsForUpdate(LocalDateTime now) {
+        return jpaRepository.findDueScheduledEventsForUpdate(now);
+    }
+
+    @Override
+    public List<NotificationEvent> findStuckProcessingEventsForUpdate(LocalDateTime updatedBefore) {
+        return jpaRepository.findStuckProcessingEventsForUpdate(updatedBefore);
     }
 }

--- a/src/main/java/com/sportsify/notification/presentation/controller/NotificationController.java
+++ b/src/main/java/com/sportsify/notification/presentation/controller/NotificationController.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -99,7 +100,7 @@ public class NotificationController implements NotificationApi {
             @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody RegisterChannelRequest request
     ) {
-        return ResponseEntity.ok(NotificationChannelResponse.from(
+        return ResponseEntity.status(HttpStatus.CREATED).body(NotificationChannelResponse.from(
                 notificationSettingService.registerChannel(memberId, request.channelType(), request.channelTarget())
         ));
     }

--- a/src/main/resources/db/migration/V2__notification-schema.sql
+++ b/src/main/resources/db/migration/V2__notification-schema.sql
@@ -1,0 +1,10 @@
+-- V2 — notification_events 컬럼 추가 (PEL 재처리 멱등성, stuck 복구)
+ALTER TABLE notification_events
+    ADD COLUMN stream_message_id VARCHAR(100) NULL,
+    ADD COLUMN updated_at        TIMESTAMP;
+
+ALTER TABLE notification_events
+    ADD CONSTRAINT uq_ne_stream_message_id UNIQUE (stream_message_id);
+
+CREATE INDEX idx_ne_processing ON notification_events (status, updated_at)
+    WHERE status = 'PROCESSING';

--- a/src/test/java/com/sportsify/notification/application/NotificationFanoutServiceTest.java
+++ b/src/test/java/com/sportsify/notification/application/NotificationFanoutServiceTest.java
@@ -3,6 +3,7 @@ package com.sportsify.notification.application;
 import com.sportsify.common.notification.NotificationEventType;
 import com.sportsify.notification.application.service.NotificationChunkService;
 import com.sportsify.notification.application.service.NotificationFanoutService;
+import com.sportsify.notification.application.service.NotificationPayloadParser;
 import com.sportsify.notification.domain.model.NotificationEvent;
 import com.sportsify.notification.domain.repository.NotificationSettingRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +19,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -28,12 +30,13 @@ class NotificationFanoutServiceTest {
 
     @Mock private NotificationSettingRepository settingRepository;
     @Mock private NotificationChunkService chunkService;
+    @Mock private NotificationPayloadParser payloadParser;
 
     private NotificationFanoutService fanoutService;
 
     @BeforeEach
     void setUp() {
-        fanoutService = new NotificationFanoutService(settingRepository, chunkService);
+        fanoutService = new NotificationFanoutService(settingRepository, chunkService, payloadParser);
     }
 
     @Test
@@ -69,6 +72,7 @@ class NotificationFanoutServiceTest {
     void fanout_결제완료_단건발송() {
         NotificationEvent event = NotificationEvent.withId(3L, NotificationEventType.PAYMENT_COMPLETED, "{}");
         String payload = "{\"paymentId\":99,\"memberId\":5,\"amount\":10000}";
+        given(payloadParser.extractMemberId(eq(payload), anyString())).willReturn(5L);
 
         fanoutService.fanout(event, NotificationEventType.PAYMENT_COMPLETED, payload);
 
@@ -83,6 +87,8 @@ class NotificationFanoutServiceTest {
     void fanout_결제완료_memberId없음_실패() {
         NotificationEvent event = NotificationEvent.withId(4L, NotificationEventType.PAYMENT_COMPLETED, "{}");
         String invalidPayload = "{\"paymentId\":99,\"amount\":10000}";
+        given(payloadParser.extractMemberId(eq(invalidPayload), anyString()))
+                .willThrow(new IllegalArgumentException("invalid memberId"));
 
         boolean result = fanoutService.fanout(event, NotificationEventType.PAYMENT_COMPLETED, invalidPayload);
 
@@ -95,6 +101,7 @@ class NotificationFanoutServiceTest {
     void fanout_채팅알림_단건발송() {
         NotificationEvent event = NotificationEvent.withId(5L, NotificationEventType.CHAT_MENTION, "{}");
         String payload = "{\"roomId\":7,\"memberId\":42}";
+        given(payloadParser.extractMemberId(eq(payload), anyString())).willReturn(42L);
 
         fanoutService.fanout(event, NotificationEventType.CHAT_MENTION, payload);
 
@@ -109,6 +116,8 @@ class NotificationFanoutServiceTest {
     void fanout_채팅알림_memberId없음_실패() {
         NotificationEvent event = NotificationEvent.withId(6L, NotificationEventType.CHAT_MENTION, "{}");
         String invalidPayload = "{\"roomId\":7}";
+        given(payloadParser.extractMemberId(eq(invalidPayload), anyString()))
+                .willThrow(new IllegalArgumentException("invalid memberId"));
 
         boolean result = fanoutService.fanout(event, NotificationEventType.CHAT_MENTION, invalidPayload);
 

--- a/src/test/java/com/sportsify/notification/application/NotificationSettingServiceTest.java
+++ b/src/test/java/com/sportsify/notification/application/NotificationSettingServiceTest.java
@@ -33,17 +33,14 @@ class NotificationSettingServiceTest {
     private NotificationChannelRepository channelRepository;
 
     @Test
-    @DisplayName("알림 설정이 없으면 기본값으로 자동 생성하여 반환한다")
-    void getSetting_없으면_기본값생성() {
-        NotificationSetting defaultSetting = NotificationSetting.createDefault(1L);
+    @DisplayName("알림 설정이 없으면 NOTIFICATION_SETTING_NOT_FOUND 예외가 발생한다")
+    void getSetting_없으면_예외() {
         given(settingRepository.findByMemberId(1L)).willReturn(Optional.empty());
-        given(settingRepository.save(any())).willReturn(defaultSetting);
 
-        var result = settingService.getSetting(1L);
-
-        assertThat(result.ticketOpenAlert()).isTrue();
-        assertThat(result.gameStartAlert()).isTrue();
-        verify(settingRepository).save(any());
+        assertThatThrownBy(() -> settingService.getSetting(1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOTIFICATION_SETTING_NOT_FOUND);
     }
 
     @Test

--- a/src/test/java/com/sportsify/notification/application/ScheduledEventClaimServiceIntegrationTest.java
+++ b/src/test/java/com/sportsify/notification/application/ScheduledEventClaimServiceIntegrationTest.java
@@ -1,0 +1,115 @@
+package com.sportsify.notification.application;
+
+import com.sportsify.common.notification.NotificationEventType;
+import com.sportsify.notification.application.service.ScheduledEventClaimService;
+import com.sportsify.notification.domain.model.NotificationEvent;
+import com.sportsify.notification.domain.model.NotificationEventStatus;
+import com.sportsify.notification.domain.repository.NotificationEventRepository;
+import com.sportsify.support.RepositoryTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScheduledEventClaimServiceIntegrationTest extends RepositoryTestSupport {
+
+    @Autowired private ScheduledEventClaimService claimService;
+    @Autowired private NotificationEventRepository eventRepository;
+    @Autowired private TransactionTemplate transactionTemplate;
+
+    @Test
+    @DisplayName("동시에 두 스레드가 claim해도 각 이벤트는 한 번만 claim된다")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void claimDueEvents_동시claim_중복없음() throws InterruptedException {
+        // GIVEN: 만기 예약 이벤트 3건 저장
+        LocalDateTime past = LocalDateTime.now().minusMinutes(1);
+        transactionTemplate.execute(status -> {
+            for (int i = 0; i < 3; i++) {
+                eventRepository.save(NotificationEvent.createScheduled(
+                        NotificationEventType.TICKET_OPEN, "{}", past));
+            }
+            return null;
+        });
+
+        // WHEN: 두 스레드가 동시에 claim
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch latch = new CountDownLatch(2);
+        CyclicBarrier barrier = new CyclicBarrier(2);
+        AtomicInteger totalClaimed = new AtomicInteger(0);
+
+        for (int i = 0; i < 2; i++) {
+            executor.submit(() -> {
+                try {
+                    barrier.await(); // 두 스레드가 동시에 진입하도록 대기
+                    List<NotificationEvent> claimed = claimService.claimDueEvents();
+                    totalClaimed.addAndGet(claimed.size());
+                } catch (Exception e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executor.shutdown();
+
+        // THEN: 두 스레드 합산 claimed 수 = 3 (중복 없음)
+        assertThat(totalClaimed.get()).isEqualTo(3);
+
+        // 모든 이벤트가 PROCESSING 상태
+        transactionTemplate.execute(status -> {
+            List<NotificationEvent> all = eventRepository.findAllById(
+                    eventRepository.findDueScheduledEventsForUpdate(LocalDateTime.now().plusHours(1))
+                            .stream().map(NotificationEvent::getId).toList()
+            );
+            // findDueScheduledEventsForUpdate는 PENDING만 조회 — PROCESSING 상태면 0건
+            assertThat(all).isEmpty();
+            return null;
+        });
+    }
+
+    @Test
+    @DisplayName("PROCESSING stuck 이벤트가 PENDING으로 복구된다")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void claimStuckEvents_PROCESSING_PENDING으로복구() {
+        // GIVEN: 15분 전에 PROCESSING 상태가 된 stuck 이벤트
+        NotificationEvent event = transactionTemplate.execute(status ->
+                eventRepository.save(NotificationEvent.createScheduled(
+                        NotificationEventType.TICKET_OPEN, "{}", LocalDateTime.now().minusMinutes(20)))
+        );
+
+        transactionTemplate.execute(status -> {
+            NotificationEvent found = eventRepository.findById(event.getId()).orElseThrow();
+            found.markProcessing();
+            return eventRepository.save(found);
+        });
+
+        // WHEN: 10분 타임아웃 기준으로 stuck 이벤트 복구
+        LocalDateTime stuckBefore = LocalDateTime.now().minusMinutes(10);
+        transactionTemplate.execute(status -> {
+            List<NotificationEvent> recovered = claimService.claimStuckEvents(stuckBefore);
+            assertThat(recovered).hasSize(1);
+            return null;
+        });
+
+        // THEN: PENDING으로 복구됨
+        transactionTemplate.execute(status -> {
+            NotificationEvent recovered = eventRepository.findById(event.getId()).orElseThrow();
+            assertThat(recovered.getStatus()).isEqualTo(NotificationEventStatus.PENDING);
+            return null;
+        });
+    }
+}

--- a/src/test/java/com/sportsify/notification/application/ScheduledEventClaimServiceIntegrationTest.java
+++ b/src/test/java/com/sportsify/notification/application/ScheduledEventClaimServiceIntegrationTest.java
@@ -6,20 +6,27 @@ import com.sportsify.notification.domain.model.NotificationEvent;
 import com.sportsify.notification.domain.model.NotificationEventStatus;
 import com.sportsify.notification.domain.repository.NotificationEventRepository;
 import com.sportsify.support.RepositoryTestSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,6 +35,20 @@ class ScheduledEventClaimServiceIntegrationTest extends RepositoryTestSupport {
     @Autowired private ScheduledEventClaimService claimService;
     @Autowired private NotificationEventRepository eventRepository;
     @Autowired private TransactionTemplate transactionTemplate;
+    @Autowired private AtomicReference<Clock> clockReference;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        clockReference.set(Clock.systemDefaultZone());
+        jdbcTemplate.execute("DELETE FROM notification_events");
+    }
+
+    @AfterEach
+    void tearDown() {
+        clockReference.set(Clock.systemDefaultZone());
+        jdbcTemplate.execute("DELETE FROM notification_events");
+    }
 
     @Test
     @DisplayName("동시에 두 스레드가 claim해도 각 이벤트는 한 번만 claim된다")
@@ -52,7 +73,7 @@ class ScheduledEventClaimServiceIntegrationTest extends RepositoryTestSupport {
         for (int i = 0; i < 2; i++) {
             executor.submit(() -> {
                 try {
-                    barrier.await(); // 두 스레드가 동시에 진입하도록 대기
+                    barrier.await();
                     List<NotificationEvent> claimed = claimService.claimDueEvents();
                     totalClaimed.addAndGet(claimed.size());
                 } catch (Exception e) {
@@ -69,14 +90,11 @@ class ScheduledEventClaimServiceIntegrationTest extends RepositoryTestSupport {
         // THEN: 두 스레드 합산 claimed 수 = 3 (중복 없음)
         assertThat(totalClaimed.get()).isEqualTo(3);
 
-        // 모든 이벤트가 PROCESSING 상태
+        // findDueScheduledEventsForUpdate는 PENDING만 조회 — PROCESSING 상태면 0건
         transactionTemplate.execute(status -> {
-            List<NotificationEvent> all = eventRepository.findAllById(
-                    eventRepository.findDueScheduledEventsForUpdate(LocalDateTime.now().plusHours(1))
-                            .stream().map(NotificationEvent::getId).toList()
-            );
-            // findDueScheduledEventsForUpdate는 PENDING만 조회 — PROCESSING 상태면 0건
-            assertThat(all).isEmpty();
+            List<NotificationEvent> pending = eventRepository.findDueScheduledEventsForUpdate(
+                    LocalDateTime.now().plusHours(1));
+            assertThat(pending).isEmpty();
             return null;
         });
     }
@@ -85,10 +103,13 @@ class ScheduledEventClaimServiceIntegrationTest extends RepositoryTestSupport {
     @DisplayName("PROCESSING stuck 이벤트가 PENDING으로 복구된다")
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     void claimStuckEvents_PROCESSING_PENDING으로복구() {
-        // GIVEN: 15분 전에 PROCESSING 상태가 된 stuck 이벤트
+        // GIVEN: Clock을 15분 전으로 고정하여 PROCESSING 상태 저장 → updated_at이 15분 전으로 기록됨
+        Clock pastClock = Clock.fixed(Instant.now().minusSeconds(15 * 60), ZoneId.systemDefault());
+        clockReference.set(pastClock);
+
         NotificationEvent event = transactionTemplate.execute(status ->
                 eventRepository.save(NotificationEvent.createScheduled(
-                        NotificationEventType.TICKET_OPEN, "{}", LocalDateTime.now().minusMinutes(20)))
+                        NotificationEventType.TICKET_OPEN, "{}", LocalDateTime.now(pastClock).minusMinutes(5)))
         );
 
         transactionTemplate.execute(status -> {
@@ -96,6 +117,9 @@ class ScheduledEventClaimServiceIntegrationTest extends RepositoryTestSupport {
             found.markProcessing();
             return eventRepository.save(found);
         });
+
+        // Clock을 현재 시각으로 복원
+        clockReference.set(Clock.systemDefaultZone());
 
         // WHEN: 10분 타임아웃 기준으로 stuck 이벤트 복구
         LocalDateTime stuckBefore = LocalDateTime.now().minusMinutes(10);

--- a/src/test/java/com/sportsify/notification/application/ScheduledNotificationProcessorTest.java
+++ b/src/test/java/com/sportsify/notification/application/ScheduledNotificationProcessorTest.java
@@ -1,0 +1,73 @@
+package com.sportsify.notification.application;
+
+import com.sportsify.common.notification.NotificationEventType;
+import com.sportsify.notification.application.service.NotificationEventProcessor;
+import com.sportsify.notification.application.service.ScheduledEventClaimService;
+import com.sportsify.notification.application.service.ScheduledNotificationProcessor;
+import com.sportsify.notification.domain.model.NotificationEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ScheduledNotificationProcessorTest {
+
+    @Mock private ScheduledEventClaimService claimService;
+    @Mock private NotificationEventProcessor eventProcessor;
+
+    private ScheduledNotificationProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        processor = new ScheduledNotificationProcessor(claimService, eventProcessor);
+    }
+
+    @Test
+    @DisplayName("만기 이벤트가 없으면 fanout을 호출하지 않는다")
+    void processDue_만기이벤트없음_fanout미호출() {
+        given(claimService.claimDueEvents()).willReturn(List.of());
+
+        processor.processDue();
+
+        verify(eventProcessor, never()).fanout(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("만기 이벤트를 조회해 eventProcessor.fanout에 위임한다")
+    void processDue_만기이벤트존재_fanout위임() {
+        NotificationEvent event = NotificationEvent.withId(1L, NotificationEventType.TICKET_OPEN, "{}");
+        given(claimService.claimDueEvents()).willReturn(List.of(event));
+
+        processor.processDue();
+
+        verify(eventProcessor).fanout(eq(event), eq(NotificationEventType.TICKET_OPEN), eq("{}"));
+    }
+
+    @Test
+    @DisplayName("하나의 이벤트 fanout 실패 시 나머지 이벤트는 계속 처리된다")
+    void processDue_일부실패_나머지계속처리() {
+        NotificationEvent event1 = NotificationEvent.withId(1L, NotificationEventType.TICKET_OPEN, "{}");
+        NotificationEvent event2 = NotificationEvent.withId(2L, NotificationEventType.GAME_START, "{}");
+        given(claimService.claimDueEvents()).willReturn(List.of(event1, event2));
+        willThrow(new RuntimeException("fanout 실패")).given(eventProcessor)
+                .fanout(eq(event1), any(), any());
+
+        processor.processDue();
+
+        verify(eventProcessor, times(2)).fanout(any(), any(), any());
+        verify(eventProcessor).fanout(eq(event2), eq(NotificationEventType.GAME_START), eq("{}"));
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,8 +4,6 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
-    lock-retry-count: 10
-
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
# Related Issues                                                                                              
                                                                                                               
-                          
                                                                                                                
## 작업 리스트                                            
                                                                                                              
  - [x] Redis Stream 기반 알림 이벤트 발행/소비 구조 구현                                                       
  - [x] 예약 알림 발송 (TICKET_OPEN, GAME_START) — **5분 주기 스케줄러**                                          
  - [x] PROCESSING stuck 이벤트 자동 복구 (10분 타임아웃)                                                       
  - [x] PEL 재처리 중복 이벤트 방지 (streamMessageId 멱등성)                                                  
  - [x] AI 코드 리뷰 피드백 반영 (null→Optional, else 제거, Enum 통합 등)                                          
                                                                                                              
  ## 작업 내용                                                                                                  
                                                                                                                
  ### 예약 알림 발송                                                                                            
  - `ScheduledNotificationProcessor`: 5분 주기로 만기 예약 이벤트 조회 후 fanout                                
  - `ScheduledEventClaimService`: `FOR UPDATE SKIP LOCKED` + `READ_COMMITTED`로 다중 인스턴스 중복 claim 방지
  - `ProcessingStuckRecoveryService`: 10분 초과 PROCESSING 이벤트를 PENDING으로 자동 복구                     
                                                                                                                
  ### PEL 재처리 버그 수정                                                                                      
  - 기존 `process()` 호출은 매번 `NotificationEvent`를 INSERT → 동일 Redis 메시지에 알림 이중 발송              
  - `notification_events.stream_message_id` 컬럼 추가, `saveEventWithStreamMessageId()`에서 이미 존재하면 기존  
  이벤트 반환                                                                                                   
  - payload 추출을 `iterator().next()` → `PAYLOAD_KEY` 직접 참조로 안전하게 변경                                
                                                                                                                
  ### SSE 타이밍 수정                                                                                           
  - SSE를 트랜잭션 커밋 전 발송 시 롤백되면 "알림 받았는데 인박스 없음" 상태 발생                               
  - `TransactionSynchronizationManager.afterCommit()`으로 커밋 확정 후 발송                                     
  - 트랜잭션 없는 단위 테스트 환경에서는 즉시 발송 (`isSynchronizationActive()` 분기)                           
                                                                                                                
  ### 코드 규칙 위반 수정                                                                                       
  - `null` → `Optional<LocalDateTime>` (`extractScheduledAt`, `parseDateTime`)                                  
  - `else` 키워드 제거 (early return 패턴으로 교체)                                                             
  - `isSingleTarget()` 로직을 `NotificationEventType` Enum 필드로 통합                                          
  - `STREAM_TO_EVENT` 중복 초기화 → `NotificationEventType.streamKeyMap()` 공통 팩토리                          
  - `NotificationChannel`, `NotificationSetting` `updatedAt` → `@LastModifiedDate` 통일                         
  - `NotificationSettingService.getSetting()` 동시성 위험 제거 (`orElseGet` → `orElseThrow`)                    
                                                                                                                
  ## 참고사항                                                                                                   
                                                                                                                
  - `TicketOpenPayload.salesStartAt` → `saleStartAt` 으로 통일 (Game 엔티티 필드명 기준)                        
  - `NotificationEventPublisher`에 이벤트 타입별 payload 매핑 Javadoc 추가 (다른 도메인 개발자 참고용)          
  - `registerChannel` 응답 코드 200 → 201 Created 