### PR TITLE
feat: support SSE authentication via query parameter token

### DIFF
--- a/src/main/java/com/sportsify/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/sportsify/infrastructure/config/SecurityConfig.java
@@ -1,15 +1,13 @@
 package com.sportsify.infrastructure.config;
 
-import com.sportsify.infrastructure.security.CustomOAuth2UserService;
-import com.sportsify.infrastructure.security.JwtAuthenticationEntryPoint;
-import com.sportsify.infrastructure.security.JwtAuthenticationFilter;
-import com.sportsify.infrastructure.security.OAuth2AuthenticationSuccessHandler;
+import com.sportsify.infrastructure.security.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -48,16 +46,26 @@ public class SecurityConfig {
             "/api/chat/rooms/**"
     );
     private static final List<String> LOCAL_ONLY_PATHS = List.of(
-            "/dev/**", "/notification-test.html", "/dev-test.html"
+            "/dev/**", "/notification-test.html", "/dev-test.html", "/checkout.html", "/success.html", "/fail.html"
     );
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private static final List<String> SSE_PATHS = List.of(
+            "/api/notifications/stream"
+    );
+
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
     private final Environment environment;
+    private final JwtProvider jwtProvider;
+    private final StringRedisTemplate redisTemplate;
 
     @Value("${app.cors.allowed-origins}")
     private List<String> allowedOrigins;
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtProvider, redisTemplate, SSE_PATHS);
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -79,7 +87,7 @@ public class SecurityConfig {
                         .userInfoEndpoint(u -> u.userService(customOAuth2UserService))
                         .successHandler(oAuth2AuthenticationSuccessHandler)
                 )
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
@@ -89,8 +97,8 @@ public class SecurityConfig {
     }
 
     @Bean
-    public FilterRegistrationBean<JwtAuthenticationFilter> jwtFilterRegistration(JwtAuthenticationFilter filter) {
-        FilterRegistrationBean<JwtAuthenticationFilter> registration = new FilterRegistrationBean<>(filter);
+    public FilterRegistrationBean<JwtAuthenticationFilter> jwtFilterRegistration() {
+        FilterRegistrationBean<JwtAuthenticationFilter> registration = new FilterRegistrationBean<>(jwtAuthenticationFilter());
         registration.setEnabled(false);
         return registration;
     }

--- a/src/main/java/com/sportsify/infrastructure/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sportsify/infrastructure/security/JwtAuthenticationFilter.java
@@ -9,14 +9,12 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
 
-@Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
@@ -24,6 +22,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
     private final StringRedisTemplate redisTemplate;
+    private final List<String> ssePaths;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -41,11 +40,27 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String resolveToken(HttpServletRequest request) {
-        String bearer = request.getHeader("Authorization");
-        if (StringUtils.hasText(bearer) && bearer.startsWith("Bearer ")) {
-            return bearer.substring(7);
+        String token = resolveBearerToken(request);
+        return token != null ? token : resolveSseToken(request);
+    }
+
+    private String resolveBearerToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (StringUtils.hasText(header) && header.startsWith("Bearer ")) {
+            return header.substring(7);
         }
         return null;
+    }
+
+    private String resolveSseToken(HttpServletRequest request) {
+        String accept = request.getHeader("Accept");
+        if (!StringUtils.hasText(accept) || !accept.contains("text/event-stream")) {
+            return null;
+        }
+        if (!ssePaths.contains(request.getRequestURI())) {
+            return null;
+        }
+        return request.getParameter("token");
     }
 
     private boolean isBlacklisted(String token) {


### PR DESCRIPTION
  # Related Issues                                                                         
                                                    
  ## 작업 리스트                                                

  - [x] JwtAuthenticationFilter SSE 쿼리 파라미터 토큰 인증 추가                           
  - [x] SecurityConfig에서 ssePaths 화이트리스트 주입 구조로 변경

  ## 작업 내용                                                                             
                                                                                           
알림 SSE 인증 방식  `?token=` 파라미터 방식으로 할 수 있도록 수정됨

                                                                                           
  ## 참고사항  

`Accept: text/event-stream` token 파라미터 방식은 협업 에서 관용적으로 사용되는 트레이드 오프 방식  입니다.
  SSE 전용 short-lived 쿠키 발급 방식이 있지만  Stateless 구조에서 쿠키 방식으로 구조가 바뀌어 전자를 택함