### PR TITLE
feat: align payment order id and publish payment events

### DIFF
--- a/src/main/java/com/sportsify/payment/application/dto/ConfirmPaymentRequest.java
+++ b/src/main/java/com/sportsify/payment/application/dto/ConfirmPaymentRequest.java
@@ -1,5 +1,6 @@
 package com.sportsify.payment.application.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -13,8 +14,9 @@ public class ConfirmPaymentRequest {
     @NotBlank(message = "paymentKey는 필수입니다.")
     private String paymentKey;
 
-    @NotBlank(message = "orderId는 필수입니다.")
-    private String orderId;
+    @JsonAlias("orderId")
+    @NotBlank(message = "tossOrderId는 필수입니다.")
+    private String tossOrderId;
 
     @NotNull(message = "amount는 필수입니다.")
     @Positive(message = "amount는 0보다 커야 합니다.")

--- a/src/main/java/com/sportsify/payment/application/dto/CreatePaymentRequest.java
+++ b/src/main/java/com/sportsify/payment/application/dto/CreatePaymentRequest.java
@@ -10,6 +10,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CreatePaymentRequest {
 
+    @NotNull(message = "orderId는 필수입니다.")
+    private Long orderId;
+
     @NotNull(message = "matchId는 필수입니다.")
     private Long matchId;
 

--- a/src/main/java/com/sportsify/payment/application/dto/CreatePaymentRequest.java
+++ b/src/main/java/com/sportsify/payment/application/dto/CreatePaymentRequest.java
@@ -11,12 +11,15 @@ import lombok.NoArgsConstructor;
 public class CreatePaymentRequest {
 
     @NotNull(message = "orderId는 필수입니다.")
+    @Positive(message = "orderId는 0보다 커야 합니다.")
     private Long orderId;
 
     @NotNull(message = "matchId는 필수입니다.")
+    @Positive(message = "matchId는 0보다 커야 합니다.")
     private Long matchId;
 
     @NotNull(message = "seatId는 필수입니다.")
+    @Positive(message = "seatId는 0보다 커야 합니다.")
     private Long seatId;
 
     @NotNull(message = "amount는 필수입니다.")

--- a/src/main/java/com/sportsify/payment/application/dto/PaymentResponse.java
+++ b/src/main/java/com/sportsify/payment/application/dto/PaymentResponse.java
@@ -11,7 +11,8 @@ import java.time.OffsetDateTime;
 public class PaymentResponse {
 
     private Long paymentId;
-    private String orderId;
+    private Long orderId;
+    private String tossOrderId;
     private String paymentKey;
     private Long amount;
     private String paymentMethod;

--- a/src/main/java/com/sportsify/payment/application/service/PaymentService.java
+++ b/src/main/java/com/sportsify/payment/application/service/PaymentService.java
@@ -1,5 +1,8 @@
 package com.sportsify.payment.application.service;
 
+import com.sportsify.common.event.PaymentCancelledEvent;
+import com.sportsify.common.event.PaymentCompletedEvent;
+import com.sportsify.common.event.PaymentStartedEvent;
 import com.sportsify.payment.application.dto.CancelPaymentRequest;
 import com.sportsify.payment.application.dto.ConfirmPaymentRequest;
 import com.sportsify.payment.application.dto.CreatePaymentRequest;
@@ -15,6 +18,7 @@ import com.sportsify.payment.infrastructure.toss.dto.TossConfirmRequest;
 import com.sportsify.payment.infrastructure.toss.dto.TossConfirmResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +37,7 @@ public class PaymentService {
 
     private final PaymentRepository paymentRepository;
     private final TossPaymentClient tossPaymentClient;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public PaymentResponse createPayment(Long userId, CreatePaymentRequest request) {
@@ -46,7 +51,8 @@ public class PaymentService {
                             .userId(userId)
                             .matchId(request.getMatchId())
                             .seatId(request.getSeatId())
-                            .orderId(generateOrderId())
+                            .orderId(request.getOrderId())
+                            .tossOrderId(generateTossOrderId(request.getOrderId()))
                             .idempotencyKey(request.getIdempotencyKey())
                             .amount(request.getAmount())
                             .paymentMethod(request.getPaymentMethod())
@@ -55,6 +61,7 @@ public class PaymentService {
                             .build();
 
                     Payment savedPayment = paymentRepository.save(payment);
+                    publishPaymentStartedEvent(savedPayment);
 
                     return toResponse(savedPayment);
                 });
@@ -62,21 +69,15 @@ public class PaymentService {
 
     @Transactional
     public PaymentResponse confirmPayment(ConfirmPaymentRequest request) {
-        Payment payment = paymentRepository.findByOrderId(request.getOrderId())
+        Payment payment = paymentRepository.findByTossOrderId(request.getTossOrderId())
                 .orElseThrow(() -> new PaymentNotFoundException("존재하지 않는 주문입니다."));
 
-        if (!payment.getAmount().equals(request.getAmount())) {
-            throw new InvalidPaymentAmountException("결제 금액이 일치하지 않습니다.");
-        }
-
-        if (payment.getStatus() != PaymentStatus.PENDING) {
-            throw new InvalidPaymentStatusException("PENDING 상태의 결제만 승인할 수 있습니다.");
-        }
+        validateConfirmablePayment(payment, request);
 
         TossConfirmResponse tossResponse = tossPaymentClient.confirm(
                 TossConfirmRequest.builder()
                         .paymentKey(request.getPaymentKey())
-                        .orderId(request.getOrderId())
+                        .orderId(request.getTossOrderId())
                         .amount(request.getAmount())
                         .build()
         );
@@ -89,29 +90,27 @@ public class PaymentService {
                 parseApprovedAt(tossResponse.getApprovedAt())
         );
 
+        publishPaymentCompletedEvent(payment);
+
         return toResponse(payment);
     }
 
     @Transactional
     public PaymentResponse confirmPaymentMock(ConfirmPaymentRequest request) {
-        Payment payment = paymentRepository.findByOrderId(request.getOrderId())
+        Payment payment = paymentRepository.findByTossOrderId(request.getTossOrderId())
                 .orElseThrow(() -> new PaymentNotFoundException("존재하지 않는 주문입니다."));
 
-        if (!payment.getAmount().equals(request.getAmount())) {
-            throw new InvalidPaymentAmountException("결제 금액이 일치하지 않습니다.");
-        }
+        validateConfirmablePayment(payment, request);
 
-        if (payment.getStatus() != PaymentStatus.PENDING) {
-            throw new InvalidPaymentStatusException("PENDING 상태의 결제만 승인할 수 있습니다.");
-        }
-
-        String mockPaymentKey = "MOCK_" + request.getOrderId();
+        String mockPaymentKey = "MOCK_" + request.getTossOrderId();
 
         payment.markCompleted(
                 mockPaymentKey,
                 "CARD",
                 OffsetDateTime.now()
         );
+
+        publishPaymentCompletedEvent(payment);
 
         return toResponse(payment);
     }
@@ -138,8 +137,19 @@ public class PaymentService {
         }
 
         payment.markCanceled(request.getCancelReason(), LocalDateTime.now());
+        publishPaymentCancelledEvent(payment, request.getCancelReason());
 
         return toResponse(payment);
+    }
+
+    private void validateConfirmablePayment(Payment payment, ConfirmPaymentRequest request) {
+        if (!payment.getAmount().equals(request.getAmount())) {
+            throw new InvalidPaymentAmountException("결제 금액이 일치하지 않습니다.");
+        }
+
+        if (payment.getStatus() != PaymentStatus.PENDING) {
+            throw new InvalidPaymentStatusException("PENDING 상태의 결제만 승인할 수 있습니다.");
+        }
     }
 
     private void validateTossConfirmResponse(
@@ -155,42 +165,91 @@ public class PaymentService {
             throw new InvalidPaymentStatusException("Toss 결제 키가 요청 정보와 일치하지 않습니다.");
         }
 
-        if (!Objects.equals(tossResponse.getOrderId(), request.getOrderId())
-                || !Objects.equals(tossResponse.getOrderId(), payment.getOrderId())) {
+        if (!Objects.equals(tossResponse.getOrderId(), request.getTossOrderId())) {
             throw new InvalidPaymentStatusException("Toss 주문 ID가 요청 정보와 일치하지 않습니다.");
         }
 
-        if (!Objects.equals(tossResponse.getTotalAmount(), request.getAmount())
-                || !Objects.equals(tossResponse.getTotalAmount(), payment.getAmount())) {
+        if (!Objects.equals(tossResponse.getTotalAmount(), payment.getAmount())) {
             throw new InvalidPaymentAmountException("Toss 결제 금액이 요청 정보와 일치하지 않습니다.");
         }
 
-        if (!TOSS_PAYMENT_DONE_STATUS.equals(tossResponse.getStatus())) {
+        if (!Objects.equals(tossResponse.getStatus(), TOSS_PAYMENT_DONE_STATUS)) {
             throw new InvalidPaymentStatusException("Toss 결제가 완료 상태가 아닙니다.");
         }
     }
 
     private void validateSamePaymentRequest(
-            Payment payment,
+            Payment existingPayment,
             Long userId,
             CreatePaymentRequest request
     ) {
-        boolean sameRequest =
-                Objects.equals(payment.getUserId(), userId)
-                        && Objects.equals(payment.getMatchId(), request.getMatchId())
-                        && Objects.equals(payment.getSeatId(), request.getSeatId())
-                        && Objects.equals(payment.getAmount(), request.getAmount())
-                        && Objects.equals(payment.getPaymentMethod(), request.getPaymentMethod());
-
-        if (!sameRequest) {
+        if (!Objects.equals(existingPayment.getUserId(), userId)
+                || !Objects.equals(existingPayment.getOrderId(), request.getOrderId())
+                || !Objects.equals(existingPayment.getMatchId(), request.getMatchId())
+                || !Objects.equals(existingPayment.getSeatId(), request.getSeatId())
+                || !Objects.equals(existingPayment.getAmount(), request.getAmount())
+                || !Objects.equals(existingPayment.getPaymentMethod(), request.getPaymentMethod())) {
             throw new InvalidPaymentStatusException("동일한 idempotencyKey로 다른 결제 요청을 생성할 수 없습니다.");
         }
+    }
+
+    private OffsetDateTime parseApprovedAt(String approvedAt) {
+        try {
+            return OffsetDateTime.parse(approvedAt);
+        } catch (DateTimeParseException e) {
+            throw new InvalidPaymentStatusException("Toss 결제 승인 시간이 올바르지 않습니다.");
+        }
+    }
+
+    private String generateTossOrderId(Long orderId) {
+        return "ORDER_" + orderId + "_" + UUID.randomUUID()
+                .toString()
+                .replace("-", "")
+                .substring(0, 20);
+    }
+
+    private void publishPaymentStartedEvent(Payment payment) {
+        eventPublisher.publishEvent(new PaymentStartedEvent(
+                payment.getOrderId(),
+                payment.getUserId(),
+                payment.getId(),
+                payment.getAmount(),
+                payment.getPaymentKey(),
+                payment.getStatus(),
+                LocalDateTime.now()
+        ));
+    }
+
+    private void publishPaymentCompletedEvent(Payment payment) {
+        eventPublisher.publishEvent(new PaymentCompletedEvent(
+                payment.getOrderId(),
+                payment.getUserId(),
+                payment.getId(),
+                payment.getAmount(),
+                payment.getPaymentKey(),
+                payment.getStatus(),
+                LocalDateTime.now()
+        ));
+    }
+
+    private void publishPaymentCancelledEvent(Payment payment, String cancelReason) {
+        eventPublisher.publishEvent(new PaymentCancelledEvent(
+                payment.getOrderId(),
+                payment.getUserId(),
+                payment.getId(),
+                payment.getAmount(),
+                payment.getPaymentKey(),
+                payment.getStatus(),
+                cancelReason,
+                LocalDateTime.now()
+        ));
     }
 
     private PaymentResponse toResponse(Payment payment) {
         return PaymentResponse.builder()
                 .paymentId(payment.getId())
                 .orderId(payment.getOrderId())
+                .tossOrderId(payment.getTossOrderId())
                 .paymentKey(payment.getPaymentKey())
                 .amount(payment.getAmount())
                 .paymentMethod(payment.getPaymentMethod())
@@ -198,25 +257,5 @@ public class PaymentService {
                 .requestedAt(payment.getRequestedAt())
                 .approvedAt(payment.getApprovedAt())
                 .build();
-    }
-
-    private String generateOrderId() {
-        return "ORDER_" + UUID.randomUUID()
-                .toString()
-                .replace("-", "")
-                .substring(0, 20);
-    }
-
-    private OffsetDateTime parseApprovedAt(String approvedAt) {
-        if (approvedAt == null || approvedAt.isBlank()) {
-            return OffsetDateTime.now();
-        }
-
-        try {
-            return OffsetDateTime.parse(approvedAt);
-        } catch (DateTimeParseException e) {
-            log.warn("Toss approvedAt 파싱 실패. approvedAt={}, fallback=now", approvedAt, e);
-            return OffsetDateTime.now();
-        }
     }
 }

--- a/src/main/java/com/sportsify/payment/application/service/PaymentService.java
+++ b/src/main/java/com/sportsify/payment/application/service/PaymentService.java
@@ -194,6 +194,10 @@ public class PaymentService {
     }
 
     private OffsetDateTime parseApprovedAt(String approvedAt) {
+        if (approvedAt == null || approvedAt.isBlank()) {
+            throw new InvalidPaymentStatusException("Toss 결제 승인 시간이 올바르지 않습니다.");
+        }
+
         try {
             return OffsetDateTime.parse(approvedAt);
         } catch (DateTimeParseException e) {

--- a/src/main/java/com/sportsify/payment/domain/entity/Payment.java
+++ b/src/main/java/com/sportsify/payment/domain/entity/Payment.java
@@ -39,8 +39,11 @@ public class Payment {
     @Column(name = "seat_id", nullable = false)
     private Long seatId;
 
-    @Column(name = "order_id", nullable = false, unique = true, length = 50)
-    private String orderId;
+    @Column(name = "order_id", nullable = false, unique = true)
+    private Long orderId;
+
+    @Column(name = "toss_order_id", nullable = false, unique = true, length = 50)
+    private String tossOrderId;
 
     @Column(name = "payment_key", unique = true, length = 100)
     private String paymentKey;
@@ -83,7 +86,8 @@ public class Payment {
             Long userId,
             Long matchId,
             Long seatId,
-            String orderId,
+            Long orderId,
+            String tossOrderId,
             String paymentKey,
             String idempotencyKey,
             Long amount,
@@ -98,6 +102,7 @@ public class Payment {
         this.matchId = matchId;
         this.seatId = seatId;
         this.orderId = orderId;
+        this.tossOrderId = tossOrderId;
         this.paymentKey = paymentKey;
         this.idempotencyKey = idempotencyKey;
         this.amount = amount;

--- a/src/main/java/com/sportsify/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/sportsify/payment/domain/repository/PaymentRepository.java
@@ -7,7 +7,9 @@ import java.util.Optional;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
-    Optional<Payment> findByOrderId(String orderId);
+    Optional<Payment> findByOrderId(Long orderId);
+
+    Optional<Payment> findByTossOrderId(String tossOrderId);
 
     Optional<Payment> findByIdempotencyKey(String idempotencyKey);
 }

--- a/src/main/resources/db/migration/V4__payment_order_event.sql
+++ b/src/main/resources/db/migration/V4__payment_order_event.sql
@@ -1,0 +1,19 @@
+-- payments.order_id를 티케팅 Order PK로 사용하고,
+-- Toss 결제용 주문번호는 toss_order_id로 분리한다.
+
+ALTER TABLE payments
+    RENAME COLUMN order_id TO toss_order_id;
+
+ALTER TABLE payments
+    ADD COLUMN order_id BIGINT;
+
+ALTER TABLE payments
+    ALTER COLUMN order_id SET NOT NULL;
+
+ALTER TABLE payments
+    ADD CONSTRAINT uk_payments_order_id_long UNIQUE (order_id);
+
+ALTER TABLE payments
+    ADD CONSTRAINT fk_payments_order_id_orders
+        FOREIGN KEY (order_id)
+            REFERENCES orders (id);

--- a/src/main/resources/db/migration/V4__payment_order_event.sql
+++ b/src/main/resources/db/migration/V4__payment_order_event.sql
@@ -1,14 +1,14 @@
--- payments.order_id를 티케팅 Order PK로 사용하고,
--- Toss 결제용 주문번호는 toss_order_id로 분리한다.
+-- payments.order_id를 Toss 결제용 주문번호에서 티케팅 Order PK로 분리한다.
+-- 기존 order_id는 toss_order_id로 변경하고,
+-- 새 order_id는 orders.id를 참조하는 FK로 추가한다.
+-- 기존 payments 데이터가 있을 수 있으므로 order_id는 nullable로 추가한다.
+-- NOT NULL 제약은 기존 데이터 백필 정책 확정 후 별도 마이그레이션에서 적용한다.
 
 ALTER TABLE payments
     RENAME COLUMN order_id TO toss_order_id;
 
 ALTER TABLE payments
     ADD COLUMN order_id BIGINT;
-
-ALTER TABLE payments
-    ALTER COLUMN order_id SET NOT NULL;
 
 ALTER TABLE payments
     ADD CONSTRAINT uk_payments_order_id_long UNIQUE (order_id);

--- a/src/test/java/com/sportsify/payment/application/service/PaymentServiceTest.java
+++ b/src/test/java/com/sportsify/payment/application/service/PaymentServiceTest.java
@@ -1,6 +1,11 @@
 package com.sportsify.payment.application.service;
 
+import com.sportsify.common.event.PaymentCancelledEvent;
+import com.sportsify.common.event.PaymentCompletedEvent;
+import com.sportsify.common.event.PaymentStartedEvent;
 import com.sportsify.payment.application.dto.CancelPaymentRequest;
+import com.sportsify.payment.application.dto.ConfirmPaymentRequest;
+import com.sportsify.payment.application.dto.CreatePaymentRequest;
 import com.sportsify.payment.application.dto.PaymentResponse;
 import com.sportsify.payment.domain.entity.Payment;
 import com.sportsify.payment.domain.exception.InvalidPaymentStatusException;
@@ -11,9 +16,11 @@ import com.sportsify.payment.infrastructure.toss.TossPaymentClient;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -22,9 +29,11 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,8 +45,74 @@ class PaymentServiceTest {
     @Mock
     private TossPaymentClient tossPaymentClient;
 
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
     @InjectMocks
     private PaymentService paymentService;
+
+    @Test
+    @DisplayName("create payment and publish started event")
+    void createPayment_success_publishPaymentStartedEvent() {
+        Long userId = 1L;
+        CreatePaymentRequest request = createPaymentRequest();
+
+        when(paymentRepository.findByIdempotencyKey("IDEMPOTENCY_KEY_123"))
+                .thenReturn(Optional.empty());
+
+        when(paymentRepository.save(any(Payment.class)))
+                .thenAnswer(invocation -> {
+                    Payment payment = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(payment, "id", 1L);
+                    return payment;
+                });
+
+        PaymentResponse response = paymentService.createPayment(userId, request);
+
+        assertThat(response.getPaymentId()).isEqualTo(1L);
+        assertThat(response.getOrderId()).isEqualTo(1L);
+        assertThat(response.getTossOrderId()).startsWith("ORDER_1_");
+        assertThat(response.getAmount()).isEqualTo(50000L);
+        assertThat(response.getStatus()).isEqualTo("PENDING");
+
+        ArgumentCaptor<PaymentStartedEvent> eventCaptor = ArgumentCaptor.forClass(PaymentStartedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+
+        PaymentStartedEvent event = eventCaptor.getValue();
+        assertThat(event.orderId()).isEqualTo(1L);
+        assertThat(event.memberId()).isEqualTo(userId);
+        assertThat(event.paymentId()).isEqualTo(1L);
+        assertThat(event.amount()).isEqualTo(50000L);
+        assertThat(event.paymentStatus()).isEqualTo(PaymentStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("confirm mock payment and publish completed event")
+    void confirmPaymentMock_success_publishPaymentCompletedEvent() {
+        ConfirmPaymentRequest request = confirmPaymentRequest();
+        Payment payment = pendingPayment();
+
+        when(paymentRepository.findByTossOrderId("ORDER_1_TEST"))
+                .thenReturn(Optional.of(payment));
+
+        PaymentResponse response = paymentService.confirmPaymentMock(request);
+
+        assertThat(response.getStatus()).isEqualTo("COMPLETED");
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.COMPLETED);
+        assertThat(payment.getPaymentKey()).isEqualTo("MOCK_ORDER_1_TEST");
+        assertThat(payment.getApprovedAt()).isNotNull();
+
+        ArgumentCaptor<PaymentCompletedEvent> eventCaptor = ArgumentCaptor.forClass(PaymentCompletedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+
+        PaymentCompletedEvent event = eventCaptor.getValue();
+        assertThat(event.orderId()).isEqualTo(1L);
+        assertThat(event.memberId()).isEqualTo(1L);
+        assertThat(event.paymentId()).isEqualTo(1L);
+        assertThat(event.amount()).isEqualTo(50000L);
+        assertThat(event.paymentKey()).isEqualTo("MOCK_ORDER_1_TEST");
+        assertThat(event.paymentStatus()).isEqualTo(PaymentStatus.COMPLETED);
+    }
 
     @Test
     @DisplayName("cancel completed payment")
@@ -56,6 +131,18 @@ class PaymentServiceTest {
         assertThat(payment.getCanceledAt()).isNotNull();
 
         verify(tossPaymentClient).cancel("PAYMENT_KEY_123", "cancel request");
+
+        ArgumentCaptor<PaymentCancelledEvent> eventCaptor = ArgumentCaptor.forClass(PaymentCancelledEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+
+        PaymentCancelledEvent event = eventCaptor.getValue();
+        assertThat(event.orderId()).isEqualTo(1L);
+        assertThat(event.memberId()).isEqualTo(1L);
+        assertThat(event.paymentId()).isEqualTo(1L);
+        assertThat(event.amount()).isEqualTo(50000L);
+        assertThat(event.paymentKey()).isEqualTo("PAYMENT_KEY_123");
+        assertThat(event.paymentStatus()).isEqualTo(PaymentStatus.CANCELED);
+        assertThat(event.failureReason()).isEqualTo("cancel request");
     }
 
     @Test
@@ -75,6 +162,7 @@ class PaymentServiceTest {
         assertThat(payment.getCanceledAt()).isNotNull();
 
         verify(tossPaymentClient, never()).cancel(anyString(), anyString());
+        verify(eventPublisher).publishEvent(any(PaymentCancelledEvent.class));
     }
 
     @Test
@@ -89,6 +177,7 @@ class PaymentServiceTest {
                 .isInstanceOf(PaymentNotFoundException.class);
 
         verify(tossPaymentClient, never()).cancel(anyString(), anyString());
+        verifyNoInteractions(eventPublisher);
     }
 
     @Test
@@ -104,6 +193,7 @@ class PaymentServiceTest {
                 .isInstanceOf(InvalidPaymentStatusException.class);
 
         verify(tossPaymentClient, never()).cancel(anyString(), anyString());
+        verifyNoInteractions(eventPublisher);
     }
 
     @Test
@@ -119,6 +209,7 @@ class PaymentServiceTest {
                 .isInstanceOf(InvalidPaymentStatusException.class);
 
         verify(tossPaymentClient, never()).cancel(anyString(), anyString());
+        verifyNoInteractions(eventPublisher);
     }
 
     @Test
@@ -134,28 +225,34 @@ class PaymentServiceTest {
                 .isInstanceOf(InvalidPaymentStatusException.class);
 
         verify(tossPaymentClient, never()).cancel(anyString(), anyString());
+        verifyNoInteractions(eventPublisher);
     }
 
     private Payment pendingPayment() {
-        return Payment.builder()
+        Payment payment = Payment.builder()
                 .userId(1L)
                 .matchId(1L)
                 .seatId(1L)
-                .orderId("ORDER_123")
+                .orderId(1L)
+                .tossOrderId("ORDER_1_TEST")
                 .idempotencyKey("IDEMPOTENCY_KEY_123")
                 .amount(50000L)
                 .paymentMethod("CARD")
                 .status(PaymentStatus.PENDING)
                 .requestedAt(LocalDateTime.now())
                 .build();
+
+        ReflectionTestUtils.setField(payment, "id", 1L);
+        return payment;
     }
 
     private Payment completedPayment(String paymentKey) {
-        return Payment.builder()
+        Payment payment = Payment.builder()
                 .userId(1L)
                 .matchId(1L)
                 .seatId(1L)
-                .orderId("ORDER_123")
+                .orderId(1L)
+                .tossOrderId("ORDER_1_TEST")
                 .paymentKey(paymentKey)
                 .idempotencyKey("IDEMPOTENCY_KEY_123")
                 .amount(50000L)
@@ -164,14 +261,18 @@ class PaymentServiceTest {
                 .requestedAt(LocalDateTime.now())
                 .approvedAt(OffsetDateTime.now())
                 .build();
+
+        ReflectionTestUtils.setField(payment, "id", 1L);
+        return payment;
     }
 
     private Payment canceledPayment() {
-        return Payment.builder()
+        Payment payment = Payment.builder()
                 .userId(1L)
                 .matchId(1L)
                 .seatId(1L)
-                .orderId("ORDER_123")
+                .orderId(1L)
+                .tossOrderId("ORDER_1_TEST")
                 .paymentKey("PAYMENT_KEY_123")
                 .idempotencyKey("IDEMPOTENCY_KEY_123")
                 .amount(50000L)
@@ -182,6 +283,28 @@ class PaymentServiceTest {
                 .canceledAt(LocalDateTime.now())
                 .cancelReason("cancel request")
                 .build();
+
+        ReflectionTestUtils.setField(payment, "id", 1L);
+        return payment;
+    }
+
+    private CreatePaymentRequest createPaymentRequest() {
+        CreatePaymentRequest request = new CreatePaymentRequest();
+        ReflectionTestUtils.setField(request, "orderId", 1L);
+        ReflectionTestUtils.setField(request, "matchId", 1L);
+        ReflectionTestUtils.setField(request, "seatId", 1L);
+        ReflectionTestUtils.setField(request, "amount", 50000L);
+        ReflectionTestUtils.setField(request, "paymentMethod", "CARD");
+        ReflectionTestUtils.setField(request, "idempotencyKey", "IDEMPOTENCY_KEY_123");
+        return request;
+    }
+
+    private ConfirmPaymentRequest confirmPaymentRequest() {
+        ConfirmPaymentRequest request = new ConfirmPaymentRequest();
+        ReflectionTestUtils.setField(request, "paymentKey", "PAYMENT_KEY_123");
+        ReflectionTestUtils.setField(request, "tossOrderId", "ORDER_1_TEST");
+        ReflectionTestUtils.setField(request, "amount", 50000L);
+        return request;
     }
 
     private CancelPaymentRequest cancelRequest(String cancelReason) {


### PR DESCRIPTION
# Related Issues

- #

## 작업 리스트

- 결제 orderId 구조 정리
- Toss 결제용 주문번호 분리
- 결제 상태 변경 이벤트 발행
- 결제 서비스 테스트 보강

## 작업 내용

- 티케팅 Order PK 기준으로 결제 `orderId`를 `Long` 타입으로 정리했습니다.
- Toss 결제용 주문번호는 `tossOrderId`로 분리했습니다.
- 결제 생성 시 `PaymentStartedEvent`를 발행하도록 추가했습니다.
- 결제 승인 성공 시 `PaymentCompletedEvent`를 발행하도록 추가했습니다.
- 결제 취소 성공 시 `PaymentCancelledEvent`를 발행하도록 추가했습니다.
- `PaymentServiceTest`에 결제 시작/완료/취소 이벤트 발행 검증을 추가했습니다.
- 기존 Flyway 마이그레이션은 수정하지 않고 `V4__payment_order_event.sql`을 새로 추가했습니다.

## 테스트

- `.\gradlew clean test --tests "com.sportsify.payment.application.service.PaymentServiceTest" --no-daemon --rerun-tasks`
  - 통과

- `.\gradlew clean test --no-daemon --rerun-tasks`
  - 통과

## 참고사항

- 티케팅 `PaymentEventListener`가 `event.orderId()`를 `OrderRepository.findById()`에 사용하므로, 결제 이벤트의 `orderId`를 티케팅 `Order` PK 기준으로 맞췄습니다.
- Toss 결제 승인 요청에 사용하는 주문번호는 `tossOrderId`로 분리했습니다.
- `PaymentFailedEvent`는 실패 시 예외/트랜잭션 롤백 흐름과 연결되어 있어 이번 PR에서는 제외했습니다.