### PR TITLE
feat: publish payment completed notification

### DIFF
--- a/src/main/java/com/sportsify/payment/application/service/PaymentService.java
+++ b/src/main/java/com/sportsify/payment/application/service/PaymentService.java
@@ -3,6 +3,9 @@ package com.sportsify.payment.application.service;
 import com.sportsify.common.event.PaymentCancelledEvent;
 import com.sportsify.common.event.PaymentCompletedEvent;
 import com.sportsify.common.event.PaymentStartedEvent;
+import com.sportsify.common.notification.NotificationEventPublisher;
+import com.sportsify.common.notification.NotificationEventType;
+import com.sportsify.common.notification.payload.PaymentCompletedPayload;
 import com.sportsify.payment.application.dto.CancelPaymentRequest;
 import com.sportsify.payment.application.dto.ConfirmPaymentRequest;
 import com.sportsify.payment.application.dto.CreatePaymentRequest;
@@ -38,6 +41,7 @@ public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final TossPaymentClient tossPaymentClient;
     private final ApplicationEventPublisher eventPublisher;
+    private final NotificationEventPublisher notificationEventPublisher;
 
     @Transactional
     public PaymentResponse createPayment(Long userId, CreatePaymentRequest request) {
@@ -91,6 +95,7 @@ public class PaymentService {
         );
 
         publishPaymentCompletedEvent(payment);
+        publishPaymentCompletedNotification(payment);
 
         return toResponse(payment);
     }
@@ -111,6 +116,7 @@ public class PaymentService {
         );
 
         publishPaymentCompletedEvent(payment);
+        publishPaymentCompletedNotification(payment);
 
         return toResponse(payment);
     }
@@ -234,6 +240,22 @@ public class PaymentService {
                 payment.getStatus(),
                 LocalDateTime.now()
         ));
+    }
+
+    private void publishPaymentCompletedNotification(Payment payment) {
+        notificationEventPublisher.publish(
+                NotificationEventType.PAYMENT_COMPLETED,
+                new PaymentCompletedPayload(
+                        payment.getId(),
+                        payment.getUserId(),
+                        Math.toIntExact(payment.getAmount())
+                )
+        );
+
+        log.info("결제 완료 알림 발행 완료. paymentId={}, userId={}",
+                payment.getId(),
+                payment.getUserId()
+        );
     }
 
     private void publishPaymentCancelledEvent(Payment payment, String cancelReason) {

--- a/src/test/java/com/sportsify/payment/application/service/PaymentServiceTest.java
+++ b/src/test/java/com/sportsify/payment/application/service/PaymentServiceTest.java
@@ -3,6 +3,9 @@ package com.sportsify.payment.application.service;
 import com.sportsify.common.event.PaymentCancelledEvent;
 import com.sportsify.common.event.PaymentCompletedEvent;
 import com.sportsify.common.event.PaymentStartedEvent;
+import com.sportsify.common.notification.NotificationEventPublisher;
+import com.sportsify.common.notification.NotificationEventType;
+import com.sportsify.common.notification.payload.PaymentCompletedPayload;
 import com.sportsify.payment.application.dto.CancelPaymentRequest;
 import com.sportsify.payment.application.dto.ConfirmPaymentRequest;
 import com.sportsify.payment.application.dto.CreatePaymentRequest;
@@ -30,6 +33,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -47,6 +51,9 @@ class PaymentServiceTest {
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private NotificationEventPublisher notificationEventPublisher;
 
     @InjectMocks
     private PaymentService paymentService;
@@ -84,6 +91,8 @@ class PaymentServiceTest {
         assertThat(event.paymentId()).isEqualTo(1L);
         assertThat(event.amount()).isEqualTo(50000L);
         assertThat(event.paymentStatus()).isEqualTo(PaymentStatus.PENDING);
+
+        verifyNoInteractions(notificationEventPublisher);
     }
 
     @Test
@@ -112,6 +121,19 @@ class PaymentServiceTest {
         assertThat(event.amount()).isEqualTo(50000L);
         assertThat(event.paymentKey()).isEqualTo("MOCK_ORDER_1_TEST");
         assertThat(event.paymentStatus()).isEqualTo(PaymentStatus.COMPLETED);
+
+        ArgumentCaptor<PaymentCompletedPayload> payloadCaptor =
+                ArgumentCaptor.forClass(PaymentCompletedPayload.class);
+
+        verify(notificationEventPublisher).publish(
+                eq(NotificationEventType.PAYMENT_COMPLETED),
+                payloadCaptor.capture()
+        );
+
+        PaymentCompletedPayload payload = payloadCaptor.getValue();
+        assertThat(payload.paymentId()).isEqualTo(1L);
+        assertThat(payload.memberId()).isEqualTo(1L);
+        assertThat(payload.amount()).isEqualTo(50000);
     }
 
     @Test
@@ -143,6 +165,8 @@ class PaymentServiceTest {
         assertThat(event.paymentKey()).isEqualTo("PAYMENT_KEY_123");
         assertThat(event.paymentStatus()).isEqualTo(PaymentStatus.CANCELED);
         assertThat(event.failureReason()).isEqualTo("cancel request");
+
+        verifyNoInteractions(notificationEventPublisher);
     }
 
     @Test
@@ -163,6 +187,7 @@ class PaymentServiceTest {
 
         verify(tossPaymentClient, never()).cancel(anyString(), anyString());
         verify(eventPublisher).publishEvent(any(PaymentCancelledEvent.class));
+        verifyNoInteractions(notificationEventPublisher);
     }
 
     @Test
@@ -178,6 +203,7 @@ class PaymentServiceTest {
 
         verify(tossPaymentClient, never()).cancel(anyString(), anyString());
         verifyNoInteractions(eventPublisher);
+        verifyNoInteractions(notificationEventPublisher);
     }
 
     @Test
@@ -194,6 +220,7 @@ class PaymentServiceTest {
 
         verify(tossPaymentClient, never()).cancel(anyString(), anyString());
         verifyNoInteractions(eventPublisher);
+        verifyNoInteractions(notificationEventPublisher);
     }
 
     @Test
@@ -210,6 +237,7 @@ class PaymentServiceTest {
 
         verify(tossPaymentClient, never()).cancel(anyString(), anyString());
         verifyNoInteractions(eventPublisher);
+        verifyNoInteractions(notificationEventPublisher);
     }
 
     @Test
@@ -226,6 +254,7 @@ class PaymentServiceTest {
 
         verify(tossPaymentClient, never()).cancel(anyString(), anyString());
         verifyNoInteractions(eventPublisher);
+        verifyNoInteractions(notificationEventPublisher);
     }
 
     private Payment pendingPayment() {


### PR DESCRIPTION
# Related Issues

- 없음

## 작업 리스트

- [x] 결제 완료 시 알림 이벤트 발행 연동
- [x] `NotificationEventPublisher` 의존성 주입
- [x] `PAYMENT_COMPLETED` 이벤트 타입 사용
- [x] `PaymentCompletedPayload`에 결제 ID, 회원 ID, 결제 금액 전달
- [x] 결제 완료 Mock API에서도 동일하게 알림 발행 처리

## 작업 내용

결제 완료 처리 시점에 알림 도메인의 `NotificationEventPublisher`를 사용하여 결제 완료 알림 이벤트를 발행하도록 연동했습니다.

결제 승인 완료 후 기존 결제 완료 이벤트(`PaymentCompletedEvent`)를 발행한 뒤, 알림 이벤트 타입 `PAYMENT_COMPLETED`와 `PaymentCompletedPayload`를 함께 전달하도록 처리했습니다.

알림 Payload에는 다음 정보를 전달합니다.

- `paymentId`: 결제 ID
- `memberId`: 결제 사용자 ID
- `amount`: 결제 금액

이를 통해 결제 도메인은 알림 발송 방식에 직접 의존하지 않고, 정해진 이벤트 타입과 Payload만 전달하도록 분리했습니다.

## 테스트

- [x] `./gradlew compileJava`

## 참고사항

현재 알림 이벤트 타입에는 `PAYMENT_COMPLETED`만 존재하므로, 이번 PR에서는 결제 완료 알림만 연동했습니다.

결제 취소 알림은 추후 `PAYMENT_CANCELLED` 이벤트 타입과 Payload가 추가되면 별도 연동 예정입니다.