### PR TITLE
Refactor: Refactor OrderExpirationScheduler

### DIFF
--- a/docs/02-erd.md
+++ b/docs/02-erd.md
@@ -530,7 +530,7 @@ CREATE INDEX idx_nh_notification ON notification_history (notification_id);
 
 ### D-5. orders.expires_at (주문 레벨 만료)
 선점 만료를 `order_seats`가 아닌 `orders` 레벨에서 관리.  
-주문 생성 시 `LocalDateTime.now().plusMinutes(15)` 설정.  
+주문 생성 시 `LocalDateTime.now().plusMinutes(10)` 설정.  
 `OrderExpirationScheduler`가 매 60초마다 만료 주문을 스캔하여 좌석 해제.
 
 ### D-6. orders 상태 확장 (PAYING, EXPIRED)

--- a/src/main/java/com/sportsify/game/domain/repository/GameSeatRepository.java
+++ b/src/main/java/com/sportsify/game/domain/repository/GameSeatRepository.java
@@ -5,6 +5,7 @@ import com.sportsify.game.domain.model.SeatStatus;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -35,4 +36,13 @@ public interface GameSeatRepository extends JpaRepository<GameSeat, Long> {
 
     @Query("SELECT gs FROM GameSeat gs WHERE gs.game.id = :gameId")
     List<GameSeat> findByGameId(Long gameId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+                UPDATE GameSeat gs SET gs.seatStatus = 'AVAILABLE'
+                WHERE gs.id IN (
+                    SELECT os.gameSeat.id FROM OrderSeat os WHERE os.order.id IN :orderIds
+                )
+            """)
+    void bulkReleaseGameSeatsByOrderIds(@Param("orderIds") List<Long> orderIds);
 }

--- a/src/main/java/com/sportsify/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/sportsify/infrastructure/config/SecurityConfig.java
@@ -45,7 +45,8 @@ public class SecurityConfig {
             "/docs.html",
             "/api/chat/rooms/**",
             "/api/chat/messages/getMessages/**",
-            "/ws/chat/**"
+            "/ws/chat/**",
+            "/actuator/**"
     );
 
     private static final List<String> LOCAL_ONLY_PATHS = List.of(

--- a/src/main/java/com/sportsify/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/sportsify/infrastructure/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
             "/api/chat/rooms/**",
             "/api/chat/messages/getMessages/**",
             "/ws/chat/**",
-            "/actuator/**"
+            "/actuator/prometheus"
     );
 
     private static final List<String> LOCAL_ONLY_PATHS = List.of(

--- a/src/main/java/com/sportsify/ticketing/application/scheduler/OrderExpirationScheduler.java
+++ b/src/main/java/com/sportsify/ticketing/application/scheduler/OrderExpirationScheduler.java
@@ -1,30 +1,30 @@
 package com.sportsify.ticketing.application.scheduler;
 
-import com.sportsify.ticketing.domain.model.Order;
-import com.sportsify.ticketing.domain.repository.OrderRepository;
+import com.sportsify.ticketing.application.service.OrderService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class OrderExpirationScheduler {
 
-    private final OrderRepository orderRepository;
+    private final OrderService orderService;
 
-    @Scheduled(fixedRate = 60000)
-    @Transactional
+    @Scheduled(fixedDelay = 1000)
     public void releaseUnpaidOrders() {
-        List<Order> expiredOrders = orderRepository
-                .findExpiredPendingOrdersWithoutPayment(LocalDateTime.now());
+        try {
+            orderService.expireUnpaidOrdersBulk();
+        } catch (RuntimeException e) {
+            log.error("[ORDER_SCHEDULER] 미결제 만료 처리 실패", e);
+        }
 
-        List<Order> failedOrders = orderRepository.findPayingOrdersWithFailedPayment();
-
-        expiredOrders.forEach(Order::expire);
-        failedOrders.forEach(Order::cancel);
+        try {
+            orderService.cancelFailedPaymentOrdersBulk();
+        } catch (RuntimeException e) {
+            log.error("[ORDER_SCHEDULER] 결제 실패 건 취소 처리 실패", e);
+        }
     }
 }

--- a/src/main/java/com/sportsify/ticketing/application/service/OrderService.java
+++ b/src/main/java/com/sportsify/ticketing/application/service/OrderService.java
@@ -1,0 +1,57 @@
+package com.sportsify.ticketing.application.service;
+
+import com.sportsify.game.domain.repository.GameSeatRepository;
+import com.sportsify.ticketing.domain.model.Order;
+import com.sportsify.ticketing.domain.model.OrderSeatStatus;
+import com.sportsify.ticketing.domain.model.OrderStatus;
+import com.sportsify.ticketing.domain.repository.OrderRepository;
+import com.sportsify.ticketing.domain.repository.OrderSeatRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrderService {
+    private final OrderRepository orderRepository;
+
+    private final OrderSeatRepository orderSeatRepository;
+
+    private final GameSeatRepository gameSeatRepository;
+
+    @Transactional
+    public void expireUnpaidOrdersBulk() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Order> orders = orderRepository.findExpiredPendingOrdersWithoutPayment(now);
+        if (orders.isEmpty()) return;
+
+        log.info("[ORDER_SCHEDULER] Unpaid Bulk size: {}", orders.size());
+
+        releaseSeatsBulk(orders, now, OrderSeatStatus.EXPIRED, OrderStatus.EXPIRED);
+    }
+
+    @Transactional
+    public void cancelFailedPaymentOrdersBulk() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Order> orders = orderRepository.findPayingOrdersWithFailedPayment();
+
+        if (orders.isEmpty()) return;
+
+        log.info("[ORDER_SCHEDULER] Failed Bulk size: {}", orders.size());
+
+        releaseSeatsBulk(orders, now, OrderSeatStatus.CANCELLED, OrderStatus.CANCELLED);
+    }
+
+    public void releaseSeatsBulk(List<Order> orders, LocalDateTime now, OrderSeatStatus orderSeatstatus, OrderStatus orderStatus) {
+        List<Long> orderIds = orders.stream().map(Order::getId).toList();
+
+        gameSeatRepository.bulkReleaseGameSeatsByOrderIds(orderIds);
+        orderSeatRepository.bulkUpdateOrderSeats(orderIds, orderSeatstatus);
+        orderRepository.bulkUpdateOrders(orderIds, orderStatus, now);
+    }
+}

--- a/src/main/java/com/sportsify/ticketing/application/service/OrderService.java
+++ b/src/main/java/com/sportsify/ticketing/application/service/OrderService.java
@@ -1,7 +1,6 @@
 package com.sportsify.ticketing.application.service;
 
 import com.sportsify.game.domain.repository.GameSeatRepository;
-import com.sportsify.ticketing.domain.model.Order;
 import com.sportsify.ticketing.domain.model.OrderSeatStatus;
 import com.sportsify.ticketing.domain.model.OrderStatus;
 import com.sportsify.ticketing.domain.repository.OrderRepository;
@@ -27,29 +26,27 @@ public class OrderService {
     @Transactional
     public void expireUnpaidOrdersBulk() {
         LocalDateTime now = LocalDateTime.now();
-        List<Order> orders = orderRepository.findExpiredPendingOrdersWithoutPayment(now);
-        if (orders.isEmpty()) return;
+        List<Long> orderIds = orderRepository.findExpiredPendingOrderIdsWithoutPayment(now);
+        if (orderIds.isEmpty()) return;
 
-        log.info("[ORDER_SCHEDULER] Unpaid Bulk size: {}", orders.size());
+        log.info("[ORDER_SCHEDULER] Unpaid Bulk size: {}", orderIds.size());
 
-        releaseSeatsBulk(orders, now, OrderSeatStatus.EXPIRED, OrderStatus.EXPIRED);
+        releaseSeatsBulk(orderIds, now, OrderSeatStatus.EXPIRED, OrderStatus.EXPIRED);
     }
 
     @Transactional
     public void cancelFailedPaymentOrdersBulk() {
         LocalDateTime now = LocalDateTime.now();
-        List<Order> orders = orderRepository.findPayingOrdersWithFailedPayment();
+        List<Long> orderIds = orderRepository.findPayingOrderIdsWithFailedPayment();
 
-        if (orders.isEmpty()) return;
+        if (orderIds.isEmpty()) return;
 
-        log.info("[ORDER_SCHEDULER] Failed Bulk size: {}", orders.size());
+        log.info("[ORDER_SCHEDULER] Failed Bulk size: {}", orderIds.size());
 
-        releaseSeatsBulk(orders, now, OrderSeatStatus.CANCELLED, OrderStatus.CANCELLED);
+        releaseSeatsBulk(orderIds, now, OrderSeatStatus.CANCELLED, OrderStatus.CANCELLED);
     }
 
-    public void releaseSeatsBulk(List<Order> orders, LocalDateTime now, OrderSeatStatus orderSeatstatus, OrderStatus orderStatus) {
-        List<Long> orderIds = orders.stream().map(Order::getId).toList();
-
+    public void releaseSeatsBulk(List<Long> orderIds, LocalDateTime now, OrderSeatStatus orderSeatstatus, OrderStatus orderStatus) {
         gameSeatRepository.bulkReleaseGameSeatsByOrderIds(orderIds);
         orderSeatRepository.bulkUpdateOrderSeats(orderIds, orderSeatstatus);
         orderRepository.bulkUpdateOrders(orderIds, orderStatus, now);

--- a/src/main/java/com/sportsify/ticketing/domain/model/Order.java
+++ b/src/main/java/com/sportsify/ticketing/domain/model/Order.java
@@ -51,7 +51,7 @@ public class Order {
     private Order(Member member) {
         this.member = member;
         this.status = OrderStatus.PENDING;
-        this.expiresAt = LocalDateTime.now().plusMinutes(15);
+        this.expiresAt = LocalDateTime.now().plusMinutes(10);
     }
 
     public static Order create(Member member) {

--- a/src/main/java/com/sportsify/ticketing/domain/repository/OrderRepository.java
+++ b/src/main/java/com/sportsify/ticketing/domain/repository/OrderRepository.java
@@ -15,9 +15,9 @@ public interface OrderRepository {
 
     Optional<Order> findByIdWithOrderSeats(Long orderId);
 
-    List<Order> findExpiredPendingOrdersWithoutPayment(LocalDateTime now);
+    List<Long> findExpiredPendingOrderIdsWithoutPayment(LocalDateTime now);
 
-    List<Order> findPayingOrdersWithFailedPayment();
+    List<Long> findPayingOrderIdsWithFailedPayment();
 
     void bulkUpdateOrders(@Param("ids") List<Long> ids, @Param("status") OrderStatus status, @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/sportsify/ticketing/domain/repository/OrderRepository.java
+++ b/src/main/java/com/sportsify/ticketing/domain/repository/OrderRepository.java
@@ -1,6 +1,8 @@
 package com.sportsify.ticketing.domain.repository;
 
 import com.sportsify.ticketing.domain.model.Order;
+import com.sportsify.ticketing.domain.model.OrderStatus;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,4 +18,6 @@ public interface OrderRepository {
     List<Order> findExpiredPendingOrdersWithoutPayment(LocalDateTime now);
 
     List<Order> findPayingOrdersWithFailedPayment();
+
+    void bulkUpdateOrders(@Param("ids") List<Long> ids, @Param("status") OrderStatus status, @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/sportsify/ticketing/domain/repository/OrderSeatRepository.java
+++ b/src/main/java/com/sportsify/ticketing/domain/repository/OrderSeatRepository.java
@@ -1,4 +1,10 @@
 package com.sportsify.ticketing.domain.repository;
 
+import com.sportsify.ticketing.domain.model.OrderSeatStatus;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
 public interface OrderSeatRepository {
+    void bulkUpdateOrderSeats(@Param("orderIds") List<Long> orderIds, @Param("status") OrderSeatStatus status);
 }

--- a/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderJpaRepository.java
+++ b/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderJpaRepository.java
@@ -1,7 +1,9 @@
 package com.sportsify.ticketing.infrastructure.repository;
 
 import com.sportsify.ticketing.domain.model.Order;
+import com.sportsify.ticketing.domain.model.OrderStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -42,4 +44,8 @@ public interface OrderJpaRepository extends JpaRepository<Order, Long> {
             """
     )
     List<Order> findPayingOrdersWithFailedPayment();
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Order o SET o.status = :status, o.updatedAt = :now WHERE o.id IN :ids")
+    void bulkUpdateOrders(@Param("ids") List<Long> ids, @Param("status") OrderStatus status, @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderJpaRepository.java
+++ b/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderJpaRepository.java
@@ -21,20 +21,16 @@ public interface OrderJpaRepository extends JpaRepository<Order, Long> {
     Optional<Order> findByIdWithOrderSeats(@Param("orderId") Long orderId);
 
     @Query("""
-             SELECT DISTINCT o FROM Order o
-             JOIN FETCH o.orderSeats os
-             JOIN FETCH os.gameSeat
+             SELECT DISTINCT o.id FROM Order o
              WHERE o.status = 'PENDING'
              AND o.expiresAt < :now
              AND NOT EXISTS(SELECT p FROM Payment p WHERE p.orderId = o.id)
             """
     )
-    List<Order> findExpiredPendingOrdersWithoutPayment(@Param("now") LocalDateTime now);
+    List<Long> findExpiredPendingOrderIdsWithoutPayment(@Param("now") LocalDateTime now);
 
     @Query("""
-             SELECT DISTINCT o FROM Order o
-             JOIN FETCH o.orderSeats os
-             JOIN FETCH os.gameSeat
+             SELECT DISTINCT o.id FROM Order o
              WHERE o.status = 'PAYING'
              AND EXISTS (
                      SELECT p FROM Payment p
@@ -43,7 +39,7 @@ public interface OrderJpaRepository extends JpaRepository<Order, Long> {
              )
             """
     )
-    List<Order> findPayingOrdersWithFailedPayment();
+    List<Long> findPayingOrderIdsWithFailedPayment();
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Order o SET o.status = :status, o.updatedAt = :now WHERE o.id IN :ids")

--- a/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderRepositoryAdapter.java
+++ b/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderRepositoryAdapter.java
@@ -2,6 +2,7 @@ package com.sportsify.ticketing.infrastructure.repository;
 
 
 import com.sportsify.ticketing.domain.model.Order;
+import com.sportsify.ticketing.domain.model.OrderStatus;
 import com.sportsify.ticketing.domain.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -41,4 +42,8 @@ public class OrderRepositoryAdapter implements OrderRepository {
         return jpaRepository.findPayingOrdersWithFailedPayment();
     }
 
+    @Override
+    public void bulkUpdateOrders(List<Long> ids, OrderStatus status, LocalDateTime now) {
+        jpaRepository.bulkUpdateOrders(ids, status, now);
+    }
 }

--- a/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderRepositoryAdapter.java
+++ b/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderRepositoryAdapter.java
@@ -33,13 +33,13 @@ public class OrderRepositoryAdapter implements OrderRepository {
     }
 
     @Override
-    public List<Order> findExpiredPendingOrdersWithoutPayment(LocalDateTime now) {
-        return jpaRepository.findExpiredPendingOrdersWithoutPayment(now);
+    public List<Long> findExpiredPendingOrderIdsWithoutPayment(LocalDateTime now) {
+        return jpaRepository.findExpiredPendingOrderIdsWithoutPayment(now);
     }
 
     @Override
-    public List<Order> findPayingOrdersWithFailedPayment() {
-        return jpaRepository.findPayingOrdersWithFailedPayment();
+    public List<Long> findPayingOrderIdsWithFailedPayment() {
+        return jpaRepository.findPayingOrderIdsWithFailedPayment();
     }
 
     @Override

--- a/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderSeatJpaRepository.java
+++ b/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderSeatJpaRepository.java
@@ -1,7 +1,17 @@
 package com.sportsify.ticketing.infrastructure.repository;
 
 import com.sportsify.ticketing.domain.model.OrderSeat;
+import com.sportsify.ticketing.domain.model.OrderSeatStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface OrderSeatJpaRepository extends JpaRepository<OrderSeat, Long> {
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE OrderSeat os SET os.status = :status WHERE os.order.id IN :orderIds")
+    void bulkUpdateOrderSeats(@Param("orderIds") List<Long> orderIds, @Param("status") OrderSeatStatus status);
+
 }

--- a/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderSeatRepositoryAdapter.java
+++ b/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderSeatRepositoryAdapter.java
@@ -1,13 +1,22 @@
 package com.sportsify.ticketing.infrastructure.repository;
 
 
+import com.sportsify.ticketing.domain.model.OrderSeatStatus;
 import com.sportsify.ticketing.domain.repository.OrderSeatRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
 public class OrderSeatRepositoryAdapter implements OrderSeatRepository {
 
     private final OrderSeatJpaRepository jpaRepository;
+
+    @Override
+    public void bulkUpdateOrderSeats(@Param("orderIds") List<Long> orderIds, @Param("status") OrderSeatStatus status) {
+        jpaRepository.bulkUpdateOrderSeats(orderIds, status);
+    }
 }

--- a/src/test/java/com/sportsify/ticketing/application/OrderExpirationSchedulerTest.java
+++ b/src/test/java/com/sportsify/ticketing/application/OrderExpirationSchedulerTest.java
@@ -14,10 +14,11 @@ import com.sportsify.ticketing.domain.model.Order;
 import com.sportsify.ticketing.domain.model.OrderSeat;
 import com.sportsify.ticketing.domain.model.OrderSeatStatus;
 import com.sportsify.ticketing.domain.model.OrderStatus;
+import com.sportsify.ticketing.domain.repository.OrderRepository;
 import com.sportsify.ticketing.fixture.TicketingTestFixture;
-import com.sportsify.ticketing.infrastructure.repository.OrderJpaRepository;
 import com.sportsify.ticketing.presentation.dto.ReservationSeatsRequestDto;
 import com.sportsify.ticketing.presentation.dto.ReservationSeatsResponseDto;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -25,18 +26,22 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Slf4j
 public class OrderExpirationSchedulerTest extends RepositoryTestSupport {
     private Member member;
     private Game game;
 
     @Autowired
-    private OrderJpaRepository orderRepository;
+    private OrderRepository orderRepository;
 
     @Autowired
     private PaymentRepository paymentRepository;
@@ -50,6 +55,9 @@ public class OrderExpirationSchedulerTest extends RepositoryTestSupport {
     @Autowired
     private TicketingTestFixture fixture;
 
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
     @BeforeEach
     void beforeEach() {
         member = fixture.createMember("t1@test.com", "n1");
@@ -61,75 +69,85 @@ public class OrderExpirationSchedulerTest extends RepositoryTestSupport {
         fixture.deleteAll();
     }
 
-
     @Test
     @DisplayName("만료된 주문의 좌석이 AVAILABLE로 복구된다")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     void expiredOrder_seatBecomesAvailable() {
-        List<Long> gameSeatIds = fixture.createGameSeatsWithCount(game, 2);
+        Long orderId = transactionTemplate.execute(txStatus -> {
+            List<Long> gameSeatIds = fixture.createGameSeatsWithCount(game, 2);
 
-        ReservationSeatsRequestDto reqDto = new ReservationSeatsRequestDto(game.getId(), gameSeatIds);
-        ReservationSeatsResponseDto resDto = reservationService.reserveSeat(member.getId(), reqDto);
-        Order order = orderRepository.findById(resDto.orderId()).orElseThrow();
+            ReservationSeatsRequestDto reqDto = new ReservationSeatsRequestDto(game.getId(), gameSeatIds);
+            ReservationSeatsResponseDto resDto = reservationService.reserveSeat(member.getId(), reqDto);
+            Order order = orderRepository.findById(resDto.orderId()).orElseThrow();
 
-        order.updateExpiresAt(LocalDateTime.now().minusMinutes(1));
-        orderRepository.save(order);
+            order.updateExpiresAt(LocalDateTime.now().minusMinutes(1));
+            return orderRepository.save(order).getId();
+        });
 
         scheduler.releaseUnpaidOrders();
 
-        Order savedOrder = orderRepository.findById(order.getId()).orElseThrow();
-        List<OrderSeat> orderSeats = savedOrder.getOrderSeats();
+        transactionTemplate.executeWithoutResult(txStatus -> {
+            Order savedOrder = orderRepository.findById(orderId).orElseThrow();
+            List<OrderSeat> orderSeats = savedOrder.getOrderSeats();
 
-        assertThat(savedOrder.getStatus()).isEqualTo(OrderStatus.EXPIRED);
-        assertThat(orderSeats)
-                .extracting(OrderSeat::getStatus)
-                .containsOnly(OrderSeatStatus.EXPIRED);
-        assertThat(orderSeats)
-                .extracting(OrderSeat::getGameSeat)
-                .extracting(GameSeat::getSeatStatus)
-                .containsOnly(SeatStatus.AVAILABLE);
+            assertThat(savedOrder.getStatus()).isEqualTo(OrderStatus.EXPIRED);
+            assertThat(orderSeats)
+                    .extracting(OrderSeat::getStatus)
+                    .containsOnly(OrderSeatStatus.EXPIRED);
+            assertThat(orderSeats)
+                    .extracting(OrderSeat::getGameSeat)
+                    .extracting(GameSeat::getSeatStatus)
+                    .containsOnly(SeatStatus.AVAILABLE);
+        });
     }
 
     @ParameterizedTest
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     @DisplayName("결제 실패/취소/환불한 주문의 좌석이 AVAILABLE로 복구된다")
     @EnumSource(value = PaymentStatus.class, names = {"FAILED", "CANCELED", "REFUNDED"})
     void payingOrderWithFailedPayment_seatBecomesAvailable(PaymentStatus status) {
-        List<Long> gameSeatIds = fixture.createGameSeatsWithCount(game, 2);
+        Long orderId = transactionTemplate.execute(txStatus -> {
+            List<Long> gameSeatIds = fixture.createGameSeatsWithCount(game, 2);
 
-        ReservationSeatsRequestDto reqDto = new ReservationSeatsRequestDto(game.getId(), gameSeatIds);
-        ReservationSeatsResponseDto resDto = reservationService.reserveSeat(member.getId(), reqDto);
-        Order order = orderRepository.findById(resDto.orderId()).orElseThrow();
+            ReservationSeatsRequestDto reqDto = new ReservationSeatsRequestDto(game.getId(), gameSeatIds);
+            ReservationSeatsResponseDto resDto = reservationService.reserveSeat(member.getId(), reqDto);
+            Order order = orderRepository.findById(resDto.orderId()).orElseThrow();
 
-        order.updateStatus(OrderStatus.PAYING);
-        orderRepository.save(order);
+            order.updateStatus(OrderStatus.PAYING);
+            orderRepository.save(order);
 
-        Payment payment = Payment.builder()
-                .userId(member.getId())
-                .matchId(game.getId())
-                .seatId(gameSeatIds.get(0))
-                .orderId(order.getId())
-                .tossOrderId("TEST_TOSS_ORDER_" + order.getId())
-                .idempotencyKey("TEST_IDEMPOTENCY_" + order.getId())
-                .amount(20000L)
-                .paymentMethod("PAY")
-                .status(status)
-                .requestedAt(LocalDateTime.now())
-                .build();
+            Payment payment = Payment.builder()
+                    .userId(member.getId())
+                    .matchId(game.getId())
+                    .seatId(gameSeatIds.get(0))
+                    .orderId(order.getId())
+                    .tossOrderId("TEST_TOSS_ORDER_" + order.getId())
+                    .idempotencyKey("TEST_IDEMPOTENCY_" + order.getId())
+                    .amount(20000L)
+                    .paymentMethod("PAY")
+                    .status(status)
+                    .requestedAt(LocalDateTime.now())
+                    .build();
 
-        paymentRepository.save(payment);
+            paymentRepository.save(payment);
+            return order.getId();
+        });
+
         scheduler.releaseUnpaidOrders();
 
-        Order savedOrder = orderRepository.findById(order.getId()).orElseThrow();
-        List<OrderSeat> orderSeats = savedOrder.getOrderSeats();
+        transactionTemplate.executeWithoutResult(txStatus -> {
+            Order savedOrder = orderRepository.findById(orderId).orElseThrow();
+            List<OrderSeat> orderSeats = savedOrder.getOrderSeats();
 
-        assertThat(savedOrder.getStatus()).isEqualTo(OrderStatus.CANCELLED);
-        assertThat(orderSeats)
-                .extracting(OrderSeat::getStatus)
-                .containsOnly(OrderSeatStatus.CANCELLED);
-        assertThat(orderSeats)
-                .extracting(OrderSeat::getGameSeat)
-                .extracting(GameSeat::getSeatStatus)
-                .containsOnly(SeatStatus.AVAILABLE);
+            assertThat(savedOrder.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+            assertThat(orderSeats)
+                    .extracting(OrderSeat::getStatus)
+                    .containsOnly(OrderSeatStatus.CANCELLED);
+            assertThat(orderSeats)
+                    .extracting(OrderSeat::getGameSeat)
+                    .extracting(GameSeat::getSeatStatus)
+                    .containsOnly(SeatStatus.AVAILABLE);
+        });
     }
-
 
 }

--- a/src/test/java/com/sportsify/ticketing/application/OrderExpirationSchedulerUnitTest.java
+++ b/src/test/java/com/sportsify/ticketing/application/OrderExpirationSchedulerUnitTest.java
@@ -1,0 +1,71 @@
+package com.sportsify.ticketing.application;
+
+import com.sportsify.ticketing.application.scheduler.OrderExpirationScheduler;
+import com.sportsify.ticketing.application.service.OrderService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(OutputCaptureExtension.class)
+class OrderExpirationSchedulerUnitTest {
+
+    @InjectMocks
+    private OrderExpirationScheduler scheduler;
+
+    @Mock
+    private OrderService orderService;
+
+    @Test
+    @DisplayName("미결제 만료 처리에서 오류가 발생하면 예외를 삼키고 로그만 남긴다.")
+    void expireUnpaidOrders_catchesException(CapturedOutput output) {
+
+        doThrow(new RuntimeException("DB 에러"))
+                .when(orderService).expireUnpaidOrdersBulk();
+
+        assertThatCode(() -> scheduler.releaseUnpaidOrders())
+                .doesNotThrowAnyException();
+
+        assertThat(output.getOut()).contains("[ORDER_SCHEDULER] 미결제 만료 처리 실패");
+        verify(orderService).cancelFailedPaymentOrdersBulk();
+
+    }
+
+    @Test
+    @DisplayName("결제 실패 취소 처리에서 오류가 발생해도 예외를 삼킨다")
+    void cancelFailedPayment_catchesException(CapturedOutput output) {
+        doThrow(new RuntimeException("DB 에러"))
+                .when(orderService).cancelFailedPaymentOrdersBulk();
+
+        assertThatCode(() -> scheduler.releaseUnpaidOrders())
+                .doesNotThrowAnyException();
+
+        assertThat(output.getOut()).contains("[ORDER_SCHEDULER] 결제 실패 건 취소 처리 실패");
+        verify(orderService).expireUnpaidOrdersBulk();
+    }
+
+    @Test
+    @DisplayName("둘 다 실패해도 예외를 삼킨다")
+    void bothFail_catchesException(CapturedOutput output) {
+        doThrow(new RuntimeException("expire 에러"))
+                .when(orderService).expireUnpaidOrdersBulk();
+        doThrow(new RuntimeException("cancel 에러"))
+                .when(orderService).cancelFailedPaymentOrdersBulk();
+
+        assertThatCode(() -> scheduler.releaseUnpaidOrders())
+                .doesNotThrowAnyException();
+
+        assertThat(output.getOut()).contains("[ORDER_SCHEDULER] 미결제 만료 처리 실패");
+        assertThat(output.getOut()).contains("[ORDER_SCHEDULER] 결제 실패 건 취소 처리 실패");
+    }
+}

--- a/src/test/java/com/sportsify/ticketing/domain/OrderTest.java
+++ b/src/test/java/com/sportsify/ticketing/domain/OrderTest.java
@@ -20,9 +20,9 @@ class OrderTest {
     void createOrderWithPendingStatus() {
         Member member = Member.create("test@test.com", "닉네임", OAuthProvider.GOOGLE, "g-1");
 
-        LocalDateTime before = LocalDateTime.now().plusMinutes(15).minusSeconds(1);
+        LocalDateTime before = LocalDateTime.now().plusMinutes(10).minusSeconds(1);
         Order order = Order.create(member);
-        LocalDateTime after = LocalDateTime.now().plusMinutes(15).plusSeconds(1);
+        LocalDateTime after = LocalDateTime.now().plusMinutes(10).plusSeconds(1);
 
         assertThat(order.getMember()).isEqualTo(member);
         assertThat(order.getStatus()).isEqualTo(OrderStatus.PENDING);

--- a/src/test/java/com/sportsify/ticketing/fixture/TicketingTestFixture.java
+++ b/src/test/java/com/sportsify/ticketing/fixture/TicketingTestFixture.java
@@ -5,6 +5,7 @@ import com.sportsify.game.domain.repository.*;
 import com.sportsify.member.domain.model.Member;
 import com.sportsify.member.domain.model.OAuthProvider;
 import com.sportsify.member.infrastructure.repository.MemberJpaRepository;
+import com.sportsify.payment.domain.repository.PaymentRepository;
 import com.sportsify.team.domain.model.SportType;
 import com.sportsify.team.domain.model.Team;
 import com.sportsify.team.infrastructure.repository.TeamJpaRepository;
@@ -45,6 +46,8 @@ public class TicketingTestFixture {
     private OrderJpaRepository orderRepository;
     @Autowired
     private OrderSeatJpaRepository orderSeatRepository;
+    @Autowired
+    private PaymentRepository paymentRepository;
 
     public Game createGame() {
         Stadium stadium = stadiumRepository.save(
@@ -139,6 +142,7 @@ public class TicketingTestFixture {
     public void deleteAll() {
         ticketRepository.deleteAll();
         orderSeatRepository.deleteAll();
+        paymentRepository.deleteAll();
         orderRepository.deleteAll();
         gameSeatRepository.deleteAll();
         pricePolicyRepository.deleteAll();

--- a/src/test/java/com/sportsify/ticketing/presentation/ReservationControllerApiTest.java
+++ b/src/test/java/com/sportsify/ticketing/presentation/ReservationControllerApiTest.java
@@ -51,7 +51,7 @@ class ReservationControllerApiTest extends WebMvcTestSupport {
                 LocalDateTime.now(),
                 50000L,
                 List.of(mock(ReservationSeatsResponseDto.ReservationSeatDto.class)),
-                LocalDateTime.now().plusMinutes(15)
+                LocalDateTime.now().plusMinutes(10)
         );
 
         when(reservationService.reserveSeat(any(), any())).thenReturn(resDto);


### PR DESCRIPTION
# Related Issues

- #79 

## 작업 리스트

스케줄러로 인한 부하 감소 및 서버 안정성 증진

- [x]  60초 주기 문제, 실시간성 해결
- [x]  TTL이 적당한지?
- [x]  만료 대상 주문 조회 시 Full Scan 발생
- [x]  동시 접근 시 락 대기
- [x]  fixedRate, fixedDelay
- [x]  Transaction AOP 문제
- [x]  N회의 update 쿼리

## 작업 내용

- 프로메테우스 모니터링(데이터) 확인 위한 `/actuator/**` public path 추가

- fixedRate 60초 -> fixedDelay 1초 변경
   - 강제로 쉬게 함으로써 인프라 환경에서 DB점유를 막기 위함
   - Select 스캔 시 Partial Index를 사용하기 때문에 1초라도 조회비용 낮음

- Bulk update 적용
   - GameSeat, OrderSeat, Order 레포지토리에 bulk query 생성
   - 기존 단일 업데이트 쿼리 삭제
   - 단일 업데이트 vs 벌크 업데이트 테스트 결과 약 3배차이 확인
      ```
     2026-05-27T10:11:51.019+09:00  INFO 23036 --- [sportsify] [    Test worker] c.s.t.application.service.OrderService   : 벌크 size: 1000
      --------------------------------------
      벌크 업데이트 소요 시간: 232ms
      --------------------------------------
      
      2026-05-27T10:11:56.841+09:00  INFO 23036 --- [sportsify] [    Test worker] c.s.t.application.service.OrderService   : 단건 size: 1000
      --------------------------------------
      단건 업데이트 소요 시간: 630ms
      --------------------------------------
      ```

- DB 커넥션과 스레드를 짧게 점유하기 위한 트랜잭션 분리
   - OrderService 내부로 select & update 로직 이동
   - 각각 try-catch문으로 에러 확인

- TTL 10분 변경(타 서비스 평균 반영)

- Scheduler 단위 & 통합테스트

## 참고사항
* 스케일 아웃 시 스케줄러 중복 실행가능성이 있기 때문에, 서버 N대로 증축 시 SKIPPED LOCK 적용 예정
* 대량 만료 건 동시 발생 시 트랜잭션 비대화 가능성 있는 것은 부하테스트를 통해 경과 확인 후 조치 예정
* 분석 리포트: [[Notion] Scheduler 문제 분석 및 개선](https://www.notion.so/Scheduler-3679e3e335cc80e19d74de68c53c1ef7?source=copy_link)