### PR TITLE
build: Update test starter coordinates for Spring Boot 4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,8 +77,8 @@ dependencies {
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.boot:spring-boot-webmvc-test'
-    testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'


### PR DESCRIPTION

# Related Issues

- #[이슈]

## 작업 리스트

- 정확한 WebMVC/Security 테스트 스타터 좌표(Group, Artifact ID) 적용을 통한 의존성 오류 조치

## 참고사항
- Spring Boot가 4.0으로 업데이트되면서 스타터 좌표가 변경됐습니다. 의존성 오류가 발생해 수정합니다.
[Migrate to Spring Boot 4.0 modular starters (Community Edition)](https://docs.openrewrite.org/recipes/java/spring/boot4/migratetomodularstarters-community-edition)

- 테스트 531개 전부 문제없이 통과하는 것을 확인했습니다.