### PR TITLE
refactor: Add OrderExpirationScheduler activate condition

### DIFF
--- a/src/main/java/com/sportsify/common/exception/ErrorCode.java
+++ b/src/main/java/com/sportsify/common/exception/ErrorCode.java
@@ -53,6 +53,8 @@ public enum ErrorCode {
     // 게임
     PRICE_POLICY_NOT_FOUND(HttpStatus.NOT_FOUND, "PRICE_POLICY_NOT_FOUND", "가격 정책이 존재하지 않습니다."),
     STADIUM_NOT_FOUND(HttpStatus.NOT_FOUND, "STADIUM_NOT_FOUND", "존재하지 않는 경기장입니다."),
+    SALE_PERIOD_BOTH_REQUIRED(HttpStatus.BAD_REQUEST, "SALE_PERIOD_BOTH_REQUIRED", "판매 시작일과 종료일은 함께 입력해야 합니다."),
+    SALE_END_BEFORE_START(HttpStatus.BAD_REQUEST, "SALE_END_BEFORE_START", "판매 종료일은 시작일 이후여야 합니다."),
 
     // 결제
     AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "AMOUNT_MISMATCH", "요청 금액이 주문 금액과 일치하지 않습니다.");

--- a/src/main/java/com/sportsify/game/application/scheduler/GameScheduleInitializer.java
+++ b/src/main/java/com/sportsify/game/application/scheduler/GameScheduleInitializer.java
@@ -2,6 +2,7 @@ package com.sportsify.game.application.scheduler;
 
 import com.sportsify.game.domain.model.Game;
 import com.sportsify.game.domain.repository.GameRepository;
+import com.sportsify.ticketing.application.scheduler.OrderExpirationScheduler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -20,6 +21,7 @@ public class GameScheduleInitializer {
     private final GameRepository gameRepository;
     private final GameSaleTaskScheduler gameSaleTaskScheduler;
     private final GameStatusUpdater gameStatusUpdater;
+    private final OrderExpirationScheduler orderExpirationScheduler;
 
     @EventListener(ApplicationReadyEvent.class)
     @Transactional
@@ -55,6 +57,7 @@ public class GameScheduleInitializer {
         List<Game> onSaleGames = gameRepository.findOnSaleGamesWithFutureSaleEnd(now);
         for (Game game : onSaleGames) {
             gameSaleTaskScheduler.scheduleSaleEnd(game.getId(), game.getSaleEndAt());
+            orderExpirationScheduler.onSaleStarted();
         }
         log.info("[GAME_SCHEDULE_INIT] 판매 종료 예약 등록 - {}건", onSaleGames.size());
     }

--- a/src/main/java/com/sportsify/game/application/scheduler/GameStatusUpdater.java
+++ b/src/main/java/com/sportsify/game/application/scheduler/GameStatusUpdater.java
@@ -5,10 +5,16 @@ import com.sportsify.common.notification.NotificationEventType;
 import com.sportsify.common.notification.payload.TicketOpenPayload;
 import com.sportsify.game.domain.model.GameStatus;
 import com.sportsify.game.domain.repository.GameRepository;
+import com.sportsify.ticketing.application.scheduler.OrderExpirationScheduler;
+import com.sportsify.ticketing.application.service.OrderService;
+import com.sportsify.ticketing.domain.model.OrderConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
 
 @Slf4j
 @Component
@@ -16,13 +22,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class GameStatusUpdater {
 
     private final GameRepository gameRepository;
+    private final OrderService orderService;
+    private final TaskScheduler gameTaskScheduler;
     private final NotificationEventPublisher notificationEventPublisher;
+    private final OrderExpirationScheduler orderExpirationScheduler;
 
-    @Transactional
     public void openSale(Long gameId) {
         gameRepository.findByIdForUpdate(gameId).ifPresent(game -> {
             if (game.getStatus() == GameStatus.SCHEDULED) {
                 game.updateStatus(GameStatus.ON_SALE);
+                orderExpirationScheduler.onSaleStarted();
 
                 notificationEventPublisher.publish(
                         NotificationEventType.TICKET_OPEN,
@@ -39,6 +48,13 @@ public class GameStatusUpdater {
         gameRepository.findByIdForUpdate(gameId).ifPresent(game -> {
             if (game.getStatus() == GameStatus.ON_SALE) {
                 game.updateStatus(GameStatus.SALE_CLOSED);
+                orderExpirationScheduler.onSaleEnded();
+
+                gameTaskScheduler.schedule(() -> {
+                    orderService.expireUnpaidOrdersBulk();
+                    orderService.cancelFailedPaymentOrdersBulk();
+                }, Instant.now().plusSeconds(OrderConstants.CLEANUP_DELAY_MINUTES * 60L));
+
                 log.info("[GAME_STATUS] SALE_CLOSED 전환 - gameId: {}", gameId);
             }
         });

--- a/src/main/java/com/sportsify/game/application/service/GameService.java
+++ b/src/main/java/com/sportsify/game/application/service/GameService.java
@@ -154,10 +154,8 @@ public class GameService {
     }
 
     private void scheduleGameSale(Game game) {
-        if (game.getSaleStartAt() != null) {
+        if (game.hasSaleSchedule()) {
             gameSaleTaskScheduler.scheduleSaleStart(game.getId(), game.getSaleStartAt());
-        }
-        if (game.getSaleEndAt() != null) {
             gameSaleTaskScheduler.scheduleSaleEnd(game.getId(), game.getSaleEndAt());
         }
     }

--- a/src/main/java/com/sportsify/game/domain/model/Game.java
+++ b/src/main/java/com/sportsify/game/domain/model/Game.java
@@ -1,6 +1,8 @@
 package com.sportsify.game.domain.model;
 
 
+import com.sportsify.common.exception.BusinessException;
+import com.sportsify.common.exception.ErrorCode;
 import com.sportsify.team.domain.model.SportType;
 import com.sportsify.team.domain.model.Team;
 import jakarta.persistence.*;
@@ -98,6 +100,15 @@ public class Game {
                               LocalDateTime startAt, Integer durationMinutes, GameStatus status,
                               DayType dayType, GameGrade gameGrade, Integer maxTicketPerUser,
                               LocalDateTime saleStartAt, LocalDateTime saleEndAt) {
+
+        if ((saleStartAt == null) != (saleEndAt == null)) {
+            throw new BusinessException(ErrorCode.SALE_PERIOD_BOTH_REQUIRED);
+        }
+
+        if (saleStartAt != null && !saleEndAt.isAfter(saleStartAt)) {
+            throw new BusinessException(ErrorCode.SALE_END_BEFORE_START);
+        }
+
         return Game.builder()
                 .stadium(stadium)
                 .homeTeam(homeTeam)
@@ -116,6 +127,10 @@ public class Game {
 
     public boolean isOnSale() {
         return this.status == GameStatus.ON_SALE;
+    }
+
+    public boolean hasSaleSchedule() {
+        return this.getSaleStartAt() != null && this.getSaleEndAt() != null;
     }
 
     public void updateStatus(GameStatus status) {

--- a/src/main/java/com/sportsify/payment/application/service/PaymentService.java
+++ b/src/main/java/com/sportsify/payment/application/service/PaymentService.java
@@ -7,6 +7,8 @@ import com.sportsify.common.exception.ErrorCode;
 import com.sportsify.common.notification.NotificationEventPublisher;
 import com.sportsify.common.notification.NotificationEventType;
 import com.sportsify.common.notification.payload.PaymentCompletedPayload;
+import com.sportsify.game.domain.model.Game;
+import com.sportsify.game.domain.repository.GameRepository;
 import com.sportsify.payment.application.dto.CancelPaymentRequest;
 import com.sportsify.payment.application.dto.ConfirmPaymentRequest;
 import com.sportsify.payment.application.dto.CreatePaymentRequest;
@@ -46,10 +48,11 @@ public class PaymentService {
     private final ApplicationEventPublisher eventPublisher;
     private final NotificationEventPublisher notificationEventPublisher;
     private final OrderRepository orderRepository;
+    private final GameRepository gameRepository;
 
     @Transactional
     public PaymentResponse createPayment(Long userId, CreatePaymentRequest request) {
-        validateOrder(request.getOrderId(), userId, request.getAmount());
+        validateOrder(request, userId);
 
         return paymentRepository.findByIdempotencyKey(request.getIdempotencyKey())
                 .map(existingPayment -> {
@@ -278,19 +281,26 @@ public class PaymentService {
                 .build();
     }
 
-    private void validateOrder(Long orderId, Long userId, Long amount) {
-        Order order = orderRepository.findByIdWithLock(orderId)
+    private void validateOrder(CreatePaymentRequest request, Long userId) {
+        Order order = orderRepository.findByIdWithLock(request.getOrderId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
+        Game game = gameRepository.findById(request.getMatchId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_FOUND));
+
+        if (!game.isOnSale()) {
+            throw new BusinessException(ErrorCode.GAME_NOT_ON_SALE);
+        }
+
         if (order.isClosed()) {
-            log.warn("결제 시작 불가 상태: orderId={}, status={}", orderId, order.getStatus());
+            log.warn("결제 시작 불가 상태: orderId={}, status={}", request.getOrderId(), order.getStatus());
             throw new BusinessException(ErrorCode.ORDER_CLOSED, "status: " + order.getStatus());
         }
 
         if (!(order.getMemberId().equals(userId)))
             throw new BusinessException(ErrorCode.ORDER_MEMBER_MISMATCH);
 
-        if (!(order.getTotalAmount().equals(amount)))
+        if (!(order.getTotalAmount().equals(request.getAmount())))
             throw new BusinessException(ErrorCode.AMOUNT_MISMATCH);
     }
 }

--- a/src/main/java/com/sportsify/payment/application/service/PaymentService.java
+++ b/src/main/java/com/sportsify/payment/application/service/PaymentService.java
@@ -285,11 +285,8 @@ public class PaymentService {
         Order order = orderRepository.findByIdWithLock(request.getOrderId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
-        Game game = gameRepository.findById(request.getMatchId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_FOUND));
-
-        if (!game.isOnSale()) {
-            throw new BusinessException(ErrorCode.GAME_NOT_ON_SALE);
+        if (!(order.getMemberId().equals(userId))) {
+            throw new BusinessException(ErrorCode.ORDER_MEMBER_MISMATCH);
         }
 
         if (order.isClosed()) {
@@ -297,10 +294,19 @@ public class PaymentService {
             throw new BusinessException(ErrorCode.ORDER_CLOSED, "status: " + order.getStatus());
         }
 
-        if (!(order.getMemberId().equals(userId)))
-            throw new BusinessException(ErrorCode.ORDER_MEMBER_MISMATCH);
-
-        if (!(order.getTotalAmount().equals(request.getAmount())))
+        if (!(order.getTotalAmount().equals(request.getAmount()))) {
             throw new BusinessException(ErrorCode.AMOUNT_MISMATCH);
+        }
+
+        Long gameId = orderRepository.findGameIdByOrderId(order.getId());
+        if (!gameId.equals(request.getMatchId())) {
+            throw new BusinessException(ErrorCode.GAME_MISMATCH);
+        }
+
+        Game game = gameRepository.findById(gameId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_FOUND));
+        if (!game.isOnSale()) {
+            throw new BusinessException(ErrorCode.GAME_NOT_ON_SALE);
+        }
     }
 }

--- a/src/main/java/com/sportsify/ticketing/application/scheduler/OrderExpirationScheduler.java
+++ b/src/main/java/com/sportsify/ticketing/application/scheduler/OrderExpirationScheduler.java
@@ -6,15 +6,30 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class OrderExpirationScheduler {
 
     private final OrderService orderService;
+    private final AtomicInteger activeSaleCount = new AtomicInteger(0);
+
+    public void onSaleStarted() {
+        activeSaleCount.incrementAndGet();
+    }
+
+    public void onSaleEnded() {
+        activeSaleCount.decrementAndGet();
+    }
 
     @Scheduled(fixedDelay = 1000)
     public void releaseUnpaidOrders() {
+        if (activeSaleCount.get() <= 0) {
+            return;
+        }
+
         try {
             orderService.expireUnpaidOrdersBulk();
         } catch (RuntimeException e) {

--- a/src/main/java/com/sportsify/ticketing/domain/model/Order.java
+++ b/src/main/java/com/sportsify/ticketing/domain/model/Order.java
@@ -54,7 +54,7 @@ public class Order {
     private Order(Member member) {
         this.member = member;
         this.status = OrderStatus.PENDING;
-        this.expiresAt = LocalDateTime.now().plusMinutes(10);
+        this.expiresAt = LocalDateTime.now().plusMinutes(OrderConstants.EXPIRATION_MINUTES);
     }
 
     public static Order create(Member member) {

--- a/src/main/java/com/sportsify/ticketing/domain/model/OrderConstants.java
+++ b/src/main/java/com/sportsify/ticketing/domain/model/OrderConstants.java
@@ -1,0 +1,6 @@
+package com.sportsify.ticketing.domain.model;
+
+public class OrderConstants {
+    public static final int EXPIRATION_MINUTES = 10;
+    public static final int CLEANUP_DELAY_MINUTES = EXPIRATION_MINUTES + 2;
+}

--- a/src/main/java/com/sportsify/ticketing/domain/model/OrderConstants.java
+++ b/src/main/java/com/sportsify/ticketing/domain/model/OrderConstants.java
@@ -1,5 +1,9 @@
 package com.sportsify.ticketing.domain.model;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class OrderConstants {
     public static final int EXPIRATION_MINUTES = 10;
     public static final int CLEANUP_DELAY_MINUTES = EXPIRATION_MINUTES + 2;

--- a/src/main/java/com/sportsify/ticketing/domain/repository/OrderRepository.java
+++ b/src/main/java/com/sportsify/ticketing/domain/repository/OrderRepository.java
@@ -15,6 +15,8 @@ public interface OrderRepository {
 
     Optional<Order> findByIdWithLock(Long id);
 
+    Long findGameIdByOrderId(@Param("orderId") Long orderId);
+
     List<Long> findExpiredPendingOrderIdsWithoutPayment(LocalDateTime now);
 
     List<Long> findPendingOrderIdsWithFailedPayment();

--- a/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderJpaRepository.java
+++ b/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderJpaRepository.java
@@ -51,6 +51,14 @@ public interface OrderJpaRepository extends JpaRepository<Order, Long> {
     @Query("SELECT o FROM Order o WHERE o.id = :id")
     Optional<Order> findByIdWithLock(@Param("id") Long id);
 
+    @Query("""
+                SELECT DISTINCT gs.id FROM Order o
+                JOIN o.orderSeats os
+                JOIN os.gameSeat gs
+                WHERE o.id = :orderId
+            """)
+    Long findGameIdByOrderId(@Param("orderId") Long orderId);
+
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Order o SET o.status = :status, o.updatedAt = :now WHERE o.id IN :ids")
     void bulkUpdateOrders(@Param("ids") List<Long> ids, @Param("status") OrderStatus status, @Param("now") LocalDateTime now);

--- a/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderRepositoryAdapter.java
+++ b/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderRepositoryAdapter.java
@@ -38,6 +38,11 @@ public class OrderRepositoryAdapter implements OrderRepository {
     }
 
     @Override
+    public Long findGameIdByOrderId(Long orderId) {
+        return jpaRepository.findGameIdByOrderId(orderId);
+    }
+
+    @Override
     public List<Long> findExpiredPendingOrderIdsWithoutPayment(LocalDateTime now) {
         return jpaRepository.findExpiredPendingOrderIdsWithoutPayment(now);
     }

--- a/src/test/java/com/sportsify/game/application/GameScheduleInitializerTest.java
+++ b/src/test/java/com/sportsify/game/application/GameScheduleInitializerTest.java
@@ -5,6 +5,7 @@ import com.sportsify.game.application.scheduler.GameScheduleInitializer;
 import com.sportsify.game.application.scheduler.GameStatusUpdater;
 import com.sportsify.game.domain.model.Game;
 import com.sportsify.game.domain.repository.GameRepository;
+import com.sportsify.ticketing.application.scheduler.OrderExpirationScheduler;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +33,9 @@ class GameScheduleInitializerTest {
 
     @Mock
     private GameStatusUpdater gameStatusUpdater;
+
+    @Mock
+    private OrderExpirationScheduler orderExpirationScheduler;
 
     @Test
     @DisplayName("서버 시작 시 saleStartAt이 지난 SCHEDULED 경기를 즉시 ON_SALE로 전환한다.")
@@ -102,5 +106,6 @@ class GameScheduleInitializerTest {
         gameScheduleInitializer.init();
 
         verify(gameSaleTaskScheduler).scheduleSaleEnd(1L, saleEndAt);
+        verify(orderExpirationScheduler).onSaleStarted();
     }
 }

--- a/src/test/java/com/sportsify/game/application/GameServiceTest.java
+++ b/src/test/java/com/sportsify/game/application/GameServiceTest.java
@@ -15,6 +15,7 @@ import com.sportsify.game.presentation.dto.GameCreateResponseDto;
 import com.sportsify.team.domain.model.SportType;
 import com.sportsify.team.domain.model.Team;
 import com.sportsify.team.domain.repository.TeamRepository;
+import com.sportsify.ticketing.application.scheduler.OrderExpirationScheduler;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,6 +52,9 @@ class GameServiceTest {
     @Mock
     private GameSaleTaskScheduler gameSaleTaskScheduler;
 
+    @Mock
+    private OrderExpirationScheduler orderExpirationScheduler;
+
 
     @Test
     @DisplayName("경기 생성 성공")
@@ -65,7 +69,7 @@ class GameServiceTest {
                 1L, 1L, 2L, SportType.BASEBALL,
                 startAt, 180, GameStatus.SCHEDULED,
                 DayType.WEEKDAY, GameGrade.NORMAL, 4,
-                startAt.minusDays(5), startAt.minusMinutes(30)
+                startAt.minusDays(5), startAt.plusDays(5)
         );
 
         when(stadiumRepository.findById(1L)).thenReturn(Optional.of(stadium));
@@ -74,7 +78,7 @@ class GameServiceTest {
 
         Game savedGame = mock(Game.class);
         when(savedGame.getSaleStartAt()).thenReturn(startAt.minusDays(5));
-        when(savedGame.getSaleEndAt()).thenReturn(startAt.minusMinutes(30));
+        when(savedGame.getSaleEndAt()).thenReturn(startAt.plusDays(5));
         when(savedGame.getId()).thenReturn(1L);
         when(savedGame.getStadium()).thenReturn(stadium);
         when(savedGame.getHomeTeam()).thenReturn(homeTeam);
@@ -86,6 +90,7 @@ class GameServiceTest {
         when(savedGame.getDayType()).thenReturn(DayType.WEEKDAY);
         when(savedGame.getGameGrade()).thenReturn(GameGrade.NORMAL);
         when(savedGame.getMaxTicketPerUser()).thenReturn(4);
+        when(savedGame.hasSaleSchedule()).thenReturn(true);
         when(stadium.getId()).thenReturn(1L);
         when(homeTeam.getId()).thenReturn(1L);
         when(awayTeam.getId()).thenReturn(2L);
@@ -103,8 +108,8 @@ class GameServiceTest {
         assertThat(response.status()).isEqualTo(GameStatus.SCHEDULED);
 
         verify(gameSaleTaskScheduler).scheduleSaleStart(eq(1L), eq(startAt.minusDays(5)));
-        verify(gameSaleTaskScheduler).scheduleSaleEnd(eq(1L), eq(startAt.minusMinutes(30)));
-        
+        verify(gameSaleTaskScheduler).scheduleSaleEnd(eq(1L), eq(startAt.plusDays(5)));
+
         verify(gameRepository).save(any(Game.class));
         verify(notificationEventPublisher).publish(eq(NotificationEventType.GAME_START), any(GameStartPayload.class));
     }

--- a/src/test/java/com/sportsify/game/application/GameStatusUpdaterTest.java
+++ b/src/test/java/com/sportsify/game/application/GameStatusUpdaterTest.java
@@ -7,13 +7,16 @@ import com.sportsify.game.application.scheduler.GameStatusUpdater;
 import com.sportsify.game.domain.model.Game;
 import com.sportsify.game.domain.model.GameStatus;
 import com.sportsify.game.domain.repository.GameRepository;
+import com.sportsify.ticketing.application.scheduler.OrderExpirationScheduler;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.TaskScheduler;
 
+import java.time.Instant;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -31,6 +34,12 @@ class GameStatusUpdaterTest {
     @Mock
     private NotificationEventPublisher notificationEventPublisher;
 
+    @Mock
+    private OrderExpirationScheduler orderExpirationScheduler;
+
+    @Mock
+    private TaskScheduler gameTaskScheduler;
+
     @Test
     @DisplayName("openSale 호출 시 SCHEDULED 상태인 경기가 ON_SALE로 변경된다.")
     void openSale_changesStatusToOnSale() {
@@ -40,6 +49,7 @@ class GameStatusUpdaterTest {
 
         gameStatusUpdater.openSale(1L);
 
+        verify(orderExpirationScheduler).onSaleStarted();
         verify(game).updateStatus(GameStatus.ON_SALE);
         verify(notificationEventPublisher).publish(eq(NotificationEventType.TICKET_OPEN), any(TicketOpenPayload.class));
     }
@@ -75,6 +85,8 @@ class GameStatusUpdaterTest {
 
         gameStatusUpdater.closeSale(1L);
 
+        verify(orderExpirationScheduler).onSaleEnded();
+        verify(gameTaskScheduler).schedule(any(Runnable.class), any(Instant.class));
         verify(game).updateStatus(GameStatus.SALE_CLOSED);
     }
 

--- a/src/test/java/com/sportsify/payment/application/service/PaymentServiceTest.java
+++ b/src/test/java/com/sportsify/payment/application/service/PaymentServiceTest.java
@@ -7,6 +7,8 @@ import com.sportsify.common.exception.ErrorCode;
 import com.sportsify.common.notification.NotificationEventPublisher;
 import com.sportsify.common.notification.NotificationEventType;
 import com.sportsify.common.notification.payload.PaymentCompletedPayload;
+import com.sportsify.game.domain.model.Game;
+import com.sportsify.game.domain.repository.GameRepository;
 import com.sportsify.payment.application.dto.CancelPaymentRequest;
 import com.sportsify.payment.application.dto.ConfirmPaymentRequest;
 import com.sportsify.payment.application.dto.CreatePaymentRequest;
@@ -49,6 +51,9 @@ class PaymentServiceTest {
     private OrderRepository orderRepository;
 
     @Mock
+    private GameRepository gameRepository;
+
+    @Mock
     private TossPaymentClient tossPaymentClient;
 
     @Mock
@@ -71,15 +76,49 @@ class PaymentServiceTest {
     }
 
     @Test
+    @DisplayName("fail when game is not found")
+    void createPayment_failed_gameIsNotFound() {
+        CreatePaymentRequest request = createPaymentRequest();
+        Order mockOrder = mock(Order.class);
+
+        when(orderRepository.findByIdWithLock(anyLong())).thenReturn(Optional.of(mockOrder));
+        
+        assertThatThrownBy(() -> paymentService.createPayment(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.GAME_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("fail when game is not on sale")
+    void createPayment_failed_gameIsNotOnSale() {
+        CreatePaymentRequest request = createPaymentRequest();
+        Order mockOrder = mock(Order.class);
+        Game mockGame = mock(Game.class);
+
+        when(mockGame.isOnSale()).thenReturn(false);
+
+        when(gameRepository.findById(anyLong())).thenReturn(Optional.of(mockGame));
+        when(orderRepository.findByIdWithLock(anyLong())).thenReturn(Optional.of(mockOrder));
+
+        assertThatThrownBy(() -> paymentService.createPayment(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.GAME_NOT_ON_SALE);
+    }
+
+    @Test
     @DisplayName("fail when order is closed")
     void createPayment_failed_orderIsClosed() {
         CreatePaymentRequest request = createPaymentRequest();
         Order mockOrder = mock(Order.class);
+        Game mockGame = mock(Game.class);
 
+        when(mockGame.isOnSale()).thenReturn(true);
         when(mockOrder.isClosed()).thenReturn(true);
 
-        when(orderRepository.findByIdWithLock(anyLong()))
-                .thenReturn(Optional.of(mockOrder));
+        when(gameRepository.findById(anyLong())).thenReturn(Optional.of(mockGame));
+        when(orderRepository.findByIdWithLock(anyLong())).thenReturn(Optional.of(mockOrder));
 
         assertThatThrownBy(() -> paymentService.createPayment(1L, request))
                 .isInstanceOf(BusinessException.class)
@@ -93,12 +132,14 @@ class PaymentServiceTest {
         Long userId = 1L;
         CreatePaymentRequest request = createPaymentRequest();
         Order mockOrder = mock(Order.class);
+        Game mockGame = mock(Game.class);
 
+        when(mockGame.isOnSale()).thenReturn(true);
         when(mockOrder.isClosed()).thenReturn(false);
         when(mockOrder.getMemberId()).thenReturn(2L);
 
-        when(orderRepository.findByIdWithLock(anyLong()))
-                .thenReturn(Optional.of(mockOrder));
+        when(gameRepository.findById(anyLong())).thenReturn(Optional.of(mockGame));
+        when(orderRepository.findByIdWithLock(anyLong())).thenReturn(Optional.of(mockOrder));
 
         assertThatThrownBy(() -> paymentService.createPayment(userId, request))
                 .isInstanceOf(BusinessException.class)
@@ -113,13 +154,15 @@ class PaymentServiceTest {
         Long userId = 1L;
         CreatePaymentRequest request = createPaymentRequest();
         Order mockOrder = mock(Order.class);
+        Game mockGame = mock(Game.class);
 
+        when(mockGame.isOnSale()).thenReturn(true);
         when(mockOrder.isClosed()).thenReturn(false);
         when(mockOrder.getMemberId()).thenReturn(userId);
         when(mockOrder.getTotalAmount()).thenReturn(10000L);
 
-        when(orderRepository.findByIdWithLock(anyLong()))
-                .thenReturn(Optional.of(mockOrder));
+        when(gameRepository.findById(anyLong())).thenReturn(Optional.of(mockGame));
+        when(orderRepository.findByIdWithLock(anyLong())).thenReturn(Optional.of(mockOrder));
 
         assertThatThrownBy(() -> paymentService.createPayment(userId, request))
                 .isInstanceOf(BusinessException.class)
@@ -134,13 +177,15 @@ class PaymentServiceTest {
         Long userId = 1L;
         CreatePaymentRequest request = createPaymentRequest();
         Order mockOrder = mock(Order.class);
+        Game mockGame = mock(Game.class);
 
+        when(mockGame.isOnSale()).thenReturn(true);
         when(mockOrder.isClosed()).thenReturn(false);
         when(mockOrder.getMemberId()).thenReturn(userId);
         when(mockOrder.getTotalAmount()).thenReturn(request.getAmount());
 
-        when(orderRepository.findByIdWithLock(anyLong()))
-                .thenReturn(Optional.of(mockOrder));
+        when(gameRepository.findById(anyLong())).thenReturn(Optional.of(mockGame));
+        when(orderRepository.findByIdWithLock(anyLong())).thenReturn(Optional.of(mockOrder));
 
         when(paymentRepository.findByIdempotencyKey("IDEMPOTENCY_KEY_123"))
                 .thenReturn(Optional.empty());

--- a/src/test/java/com/sportsify/payment/application/service/PaymentServiceTest.java
+++ b/src/test/java/com/sportsify/payment/application/service/PaymentServiceTest.java
@@ -67,8 +67,11 @@ class PaymentServiceTest {
 
     @Test
     @DisplayName("fail when order is not found in DB")
-    void createPayment_failed_orderNotFound() {
+    void createPayment_orderNotFound() {
         CreatePaymentRequest request = createPaymentRequest();
+
+        when(orderRepository.findByIdWithLock(anyLong())).thenReturn(Optional.empty());
+
         assertThatThrownBy(() -> paymentService.createPayment(1L, request))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
@@ -76,48 +79,28 @@ class PaymentServiceTest {
     }
 
     @Test
-    @DisplayName("fail when game is not found")
-    void createPayment_failed_gameIsNotFound() {
+    @DisplayName("fail when order's owner is not matched with request userId")
+    void createPayment_memberMismatch() {
         CreatePaymentRequest request = createPaymentRequest();
         Order mockOrder = mock(Order.class);
 
-        when(orderRepository.findByIdWithLock(anyLong())).thenReturn(Optional.of(mockOrder));
-        
-        assertThatThrownBy(() -> paymentService.createPayment(1L, request))
-                .isInstanceOf(BusinessException.class)
-                .extracting(e -> ((BusinessException) e).getErrorCode())
-                .isEqualTo(ErrorCode.GAME_NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("fail when game is not on sale")
-    void createPayment_failed_gameIsNotOnSale() {
-        CreatePaymentRequest request = createPaymentRequest();
-        Order mockOrder = mock(Order.class);
-        Game mockGame = mock(Game.class);
-
-        when(mockGame.isOnSale()).thenReturn(false);
-
-        when(gameRepository.findById(anyLong())).thenReturn(Optional.of(mockGame));
+        when(mockOrder.getMemberId()).thenReturn(2L);
         when(orderRepository.findByIdWithLock(anyLong())).thenReturn(Optional.of(mockOrder));
 
         assertThatThrownBy(() -> paymentService.createPayment(1L, request))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
-                .isEqualTo(ErrorCode.GAME_NOT_ON_SALE);
+                .isEqualTo(ErrorCode.ORDER_MEMBER_MISMATCH);
     }
 
     @Test
     @DisplayName("fail when order is closed")
-    void createPayment_failed_orderIsClosed() {
+    void createPayment_orderClosed() {
         CreatePaymentRequest request = createPaymentRequest();
         Order mockOrder = mock(Order.class);
-        Game mockGame = mock(Game.class);
 
-        when(mockGame.isOnSale()).thenReturn(true);
+        when(mockOrder.getMemberId()).thenReturn(1L);
         when(mockOrder.isClosed()).thenReturn(true);
-
-        when(gameRepository.findById(anyLong())).thenReturn(Optional.of(mockGame));
         when(orderRepository.findByIdWithLock(anyLong())).thenReturn(Optional.of(mockOrder));
 
         assertThatThrownBy(() -> paymentService.createPayment(1L, request))
@@ -127,49 +110,79 @@ class PaymentServiceTest {
     }
 
     @Test
-    @DisplayName("fail when order's memberId not equals to requested userId")
-    void createPayment_failed_userIdMismatch() {
-        Long userId = 1L;
-        CreatePaymentRequest request = createPaymentRequest();
+    @DisplayName("fail when order's amount is not matched with request amount")
+    void createPayment_amountMismatch() {
+        CreatePaymentRequest request = createPaymentRequest(); // amount=50000
         Order mockOrder = mock(Order.class);
-        Game mockGame = mock(Game.class);
 
-        when(mockGame.isOnSale()).thenReturn(true);
+        when(mockOrder.getMemberId()).thenReturn(1L);
         when(mockOrder.isClosed()).thenReturn(false);
-        when(mockOrder.getMemberId()).thenReturn(2L);
-
-        when(gameRepository.findById(anyLong())).thenReturn(Optional.of(mockGame));
-        when(orderRepository.findByIdWithLock(anyLong())).thenReturn(Optional.of(mockOrder));
-
-        assertThatThrownBy(() -> paymentService.createPayment(userId, request))
-                .isInstanceOf(BusinessException.class)
-                .extracting(e -> ((BusinessException) e).getErrorCode())
-                .isEqualTo(ErrorCode.ORDER_MEMBER_MISMATCH);
-    }
-
-
-    @Test
-    @DisplayName("fail when order's totalAmount not equals to requested amount")
-    void createPayment_failed_amountMismatch() {
-        Long userId = 1L;
-        CreatePaymentRequest request = createPaymentRequest();
-        Order mockOrder = mock(Order.class);
-        Game mockGame = mock(Game.class);
-
-        when(mockGame.isOnSale()).thenReturn(true);
-        when(mockOrder.isClosed()).thenReturn(false);
-        when(mockOrder.getMemberId()).thenReturn(userId);
         when(mockOrder.getTotalAmount()).thenReturn(10000L);
-
-        when(gameRepository.findById(anyLong())).thenReturn(Optional.of(mockGame));
         when(orderRepository.findByIdWithLock(anyLong())).thenReturn(Optional.of(mockOrder));
 
-        assertThatThrownBy(() -> paymentService.createPayment(userId, request))
+        assertThatThrownBy(() -> paymentService.createPayment(1L, request))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.AMOUNT_MISMATCH);
     }
 
+    @Test
+    @DisplayName("fail when game id is not matched with request matchId")
+    void createPayment_gameMismatch() {
+        CreatePaymentRequest request = createPaymentRequest(); // matchId=1
+        Order mockOrder = mock(Order.class);
+
+        when(mockOrder.getMemberId()).thenReturn(1L);
+        when(mockOrder.isClosed()).thenReturn(false);
+        when(mockOrder.getTotalAmount()).thenReturn(50000L);
+        when(orderRepository.findByIdWithLock(anyLong())).thenReturn(Optional.of(mockOrder));
+        when(orderRepository.findGameIdByOrderId(anyLong())).thenReturn(-1L);
+
+        assertThatThrownBy(() -> paymentService.createPayment(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.GAME_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("fail when game is not found in DB")
+    void createPayment_gameNotFound() {
+        CreatePaymentRequest request = createPaymentRequest();
+        Order mockOrder = mock(Order.class);
+
+        when(mockOrder.getMemberId()).thenReturn(1L);
+        when(mockOrder.isClosed()).thenReturn(false);
+        when(mockOrder.getTotalAmount()).thenReturn(50000L);
+        when(orderRepository.findByIdWithLock(anyLong())).thenReturn(Optional.of(mockOrder));
+        when(orderRepository.findGameIdByOrderId(anyLong())).thenReturn(1L);
+        when(gameRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> paymentService.createPayment(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.GAME_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("fail when game is not on sale")
+    void createPayment_gameNotOnSale() {
+        CreatePaymentRequest request = createPaymentRequest();
+        Order mockOrder = mock(Order.class);
+        Game mockGame = mock(Game.class);
+
+        when(mockOrder.getMemberId()).thenReturn(1L);
+        when(mockOrder.isClosed()).thenReturn(false);
+        when(mockOrder.getTotalAmount()).thenReturn(50000L);
+        when(mockGame.isOnSale()).thenReturn(false);
+        when(orderRepository.findByIdWithLock(anyLong())).thenReturn(Optional.of(mockOrder));
+        when(orderRepository.findGameIdByOrderId(anyLong())).thenReturn(1L);
+        when(gameRepository.findById(anyLong())).thenReturn(Optional.of(mockGame));
+
+        assertThatThrownBy(() -> paymentService.createPayment(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.GAME_NOT_ON_SALE);
+    }
 
     @Test
     @DisplayName("create payment and publish started event")
@@ -179,13 +192,14 @@ class PaymentServiceTest {
         Order mockOrder = mock(Order.class);
         Game mockGame = mock(Game.class);
 
-        when(mockGame.isOnSale()).thenReturn(true);
-        when(mockOrder.isClosed()).thenReturn(false);
         when(mockOrder.getMemberId()).thenReturn(userId);
-        when(mockOrder.getTotalAmount()).thenReturn(request.getAmount());
+        when(mockOrder.isClosed()).thenReturn(false);
+        when(mockOrder.getTotalAmount()).thenReturn(50000L);
+        when(mockGame.isOnSale()).thenReturn(true);
 
-        when(gameRepository.findById(anyLong())).thenReturn(Optional.of(mockGame));
         when(orderRepository.findByIdWithLock(anyLong())).thenReturn(Optional.of(mockOrder));
+        when(orderRepository.findGameIdByOrderId(anyLong())).thenReturn(1L);
+        when(gameRepository.findById(anyLong())).thenReturn(Optional.of(mockGame));
 
         when(paymentRepository.findByIdempotencyKey("IDEMPOTENCY_KEY_123"))
                 .thenReturn(Optional.empty());

--- a/src/test/java/com/sportsify/ticketing/application/OrderExpirationSchedulerTest.java
+++ b/src/test/java/com/sportsify/ticketing/application/OrderExpirationSchedulerTest.java
@@ -72,6 +72,7 @@ public class OrderExpirationSchedulerTest extends RepositoryTestSupport {
     void beforeEach() {
         member = fixture.createMember("t1@test.com", "n1");
         game = fixture.createGame();
+        scheduler.onSaleStarted();
     }
 
     @AfterEach

--- a/src/test/java/com/sportsify/ticketing/application/OrderExpirationSchedulerUnitTest.java
+++ b/src/test/java/com/sportsify/ticketing/application/OrderExpirationSchedulerUnitTest.java
@@ -13,8 +13,7 @@ import org.springframework.boot.test.system.OutputCaptureExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(OutputCaptureExtension.class)
@@ -26,9 +25,33 @@ class OrderExpirationSchedulerUnitTest {
     @Mock
     private OrderService orderService;
 
+
+    @Test
+    @DisplayName("판매 중인 게임이 없으면 스케줄러가 DB 조회를 하지 않는다")
+    void schedulerSkipsWhenNoActiveSale() {
+        scheduler.onSaleStarted();
+        scheduler.onSaleEnded();
+        scheduler.releaseUnpaidOrders();
+
+        verify(orderService, never()).expireUnpaidOrdersBulk();
+        verify(orderService, never()).cancelFailedPaymentOrdersBulk();
+    }
+
+    @Test
+    @DisplayName("판매 중일 때 스케줄러가 DB 조회를 실행한다")
+    void schedulerRunsWhenSaleActive() {
+        scheduler.onSaleStarted();
+
+        scheduler.releaseUnpaidOrders();
+
+        verify(orderService).expireUnpaidOrdersBulk();
+        verify(orderService).cancelFailedPaymentOrdersBulk();
+    }
+
     @Test
     @DisplayName("미결제 만료 처리에서 오류가 발생하면 예외를 삼키고 로그만 남긴다.")
     void expireUnpaidOrders_catchesException(CapturedOutput output) {
+        scheduler.onSaleStarted();
 
         doThrow(new RuntimeException("DB 에러"))
                 .when(orderService).expireUnpaidOrdersBulk();
@@ -44,6 +67,8 @@ class OrderExpirationSchedulerUnitTest {
     @Test
     @DisplayName("결제 실패 취소 처리에서 오류가 발생해도 예외를 삼킨다")
     void cancelFailedPayment_catchesException(CapturedOutput output) {
+        scheduler.onSaleStarted();
+
         doThrow(new RuntimeException("DB 에러"))
                 .when(orderService).cancelFailedPaymentOrdersBulk();
 
@@ -57,6 +82,8 @@ class OrderExpirationSchedulerUnitTest {
     @Test
     @DisplayName("둘 다 실패해도 예외를 삼킨다")
     void bothFail_catchesException(CapturedOutput output) {
+        scheduler.onSaleStarted();
+        
         doThrow(new RuntimeException("expire 에러"))
                 .when(orderService).expireUnpaidOrdersBulk();
         doThrow(new RuntimeException("cancel 에러"))

--- a/src/test/java/com/sportsify/ticketing/application/ReservationServiceIntegrationTest.java
+++ b/src/test/java/com/sportsify/ticketing/application/ReservationServiceIntegrationTest.java
@@ -6,6 +6,7 @@ import com.sportsify.member.domain.model.Member;
 import com.sportsify.support.RepositoryTestSupport;
 import com.sportsify.ticketing.application.service.ReservationService;
 import com.sportsify.ticketing.domain.model.Order;
+import com.sportsify.ticketing.domain.model.OrderConstants;
 import com.sportsify.ticketing.fixture.TicketingTestFixture;
 import com.sportsify.ticketing.infrastructure.repository.OrderJpaRepository;
 import com.sportsify.ticketing.presentation.dto.ReservationSeatsRequestDto;
@@ -74,7 +75,7 @@ class ReservationServiceIntegrationTest extends RepositoryTestSupport {
 
         LocalDateTime now = LocalDateTime.now();
 
-        assertThat(createdOrder.getExpiresAt()).isAfter(now).isBefore(now.plusMinutes(10));
+        assertThat(createdOrder.getExpiresAt()).isAfter(now).isBefore(now.plusMinutes(OrderConstants.EXPIRATION_MINUTES));
         assertThat(createdOrder.getCreatedAt()).isNotNull();
     }
 

--- a/src/test/java/com/sportsify/ticketing/domain/OrderTest.java
+++ b/src/test/java/com/sportsify/ticketing/domain/OrderTest.java
@@ -3,6 +3,7 @@ package com.sportsify.ticketing.domain;
 import com.sportsify.member.domain.model.Member;
 import com.sportsify.member.domain.model.OAuthProvider;
 import com.sportsify.ticketing.domain.model.Order;
+import com.sportsify.ticketing.domain.model.OrderConstants;
 import com.sportsify.ticketing.domain.model.OrderSeat;
 import com.sportsify.ticketing.domain.model.OrderStatus;
 import org.junit.jupiter.api.DisplayName;
@@ -23,9 +24,9 @@ class OrderTest {
     void order_createOrderWithPendingStatus() {
         Member member = Member.create("test@test.com", "닉네임", OAuthProvider.GOOGLE, "g-1");
 
-        LocalDateTime before = LocalDateTime.now().plusMinutes(10).minusSeconds(1);
+        LocalDateTime before = LocalDateTime.now().plusMinutes(OrderConstants.EXPIRATION_MINUTES).minusSeconds(1);
         Order order = Order.create(member);
-        LocalDateTime after = LocalDateTime.now().plusMinutes(10).plusSeconds(1);
+        LocalDateTime after = LocalDateTime.now().plusMinutes(OrderConstants.EXPIRATION_MINUTES).plusSeconds(1);
 
         assertThat(order.getMember()).isEqualTo(member);
         assertThat(order.getStatus()).isEqualTo(OrderStatus.PENDING);


### PR DESCRIPTION
# Related Issues

- #95 

## 작업 리스트

- OrderExpirationScheduler 스케줄러 활성/비활성 처리
- 게임 판매 종료 보완
- PaymentService - validateOrder 보완

## 작업 내용

- activeSaleCount로 스케줄러 가동/종료 관리
  - ON_SALE 상태가 1개 이상일 경우 가동
  - 0개 이하일 경우 종료
  - GameStatusUpdater: sale_start_at, sale_end_at 시각에 따라 activeSaleCount 증감 호출
- 스케줄러 가동 보장
  - GameScheduleInitializer: 서버 재시작 시 ON_SALE 게임 확인 → 스케줄러 가동
- 스케줄러 종료 보장
  - Game create 수정: sale_start_at과 sale_end_at은 둘다 있거나, 없도록 설정
- 게임 판매 종료 보완
  - PaymentService: 결제 진입 차단 검증 추가
- 테스트 수정

## 참고사항
[[Notion] 24h 스케줄러 DB I/O 부담 문제](https://www.notion.so/24h-DB-I-O-3759e3e335cc80318850d6dc5e899999?source=copy_link)