### PR TITLE
feat: expose Grafana monitoring dashboard via /grafana/ reverse proxy

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -54,11 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
 
-    # 배포 정상 테스트로 임시로 pr전 수정 필수 코드리뷰 불필요
-    if: >
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'push' && !github.event.pull_request)
-    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -53,7 +53,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build-and-test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    # 배포 정상 테스트로 임시로 pr전 수정 필수 코드리뷰 불필요
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' && !github.event.pull_request)
+    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -86,6 +86,14 @@ jobs:
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
+      - name: Prepare directories on EC2
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          script: mkdir -p ~/nginx ~/monitoring
+
       - name: Copy compose and nginx files to EC2
         uses: appleboy/scp-action@v0.1.7
         with:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -97,7 +97,9 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
-          script: mkdir -p ~/nginx ~/monitoring/grafana/provisioning ~/monitoring/grafana/dashboards
+          script: |
+            mkdir -p ~/nginx ~/monitoring/grafana/provisioning/datasources ~/monitoring/grafana/provisioning/dashboards ~/monitoring/grafana/dashboards
+            sudo chown -R $USER:$USER ~/monitoring ~/nginx
 
       - name: Copy compose and nginx files to EC2
         uses: appleboy/scp-action@v0.1.7

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -97,7 +97,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
-          script: mkdir -p ~/nginx ~/monitoring
+          script: mkdir -p ~/nginx ~/monitoring/grafana/provisioning ~/monitoring/grafana/dashboards
 
       - name: Copy compose and nginx files to EC2
         uses: appleboy/scp-action@v0.1.7
@@ -105,7 +105,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
-          source: "docker-compose.prod.yml,docker-compose.infra.yml,nginx/nginx.conf,nginx/proxy_headers.conf,monitoring/prometheus.yml"
+          source: "docker-compose.prod.yml,docker-compose.infra.yml,nginx/nginx.conf,nginx/proxy_headers.conf,monitoring/prometheus.yml,monitoring/grafana/provisioning,monitoring/grafana/dashboards"
           target: "~/"
           overwrite: true
 

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -59,11 +59,12 @@ services:
     image: grafana/grafana:latest
     container_name: sportsify-grafana
     ports:
-      - "127.0.0.1:3001:3000"   # ALB 또는 SSH 터널로만 접근
+      - "3001:3000"   # 외부 접근 허용 — AWS 보안 그룹에서 3001 포트 제어
     environment:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
       GF_SERVER_ROOT_URL: "%(protocol)s://%(domain)s/grafana/"
+      GF_SERVER_SERVE_FROM_SUB_PATH: "true"
       GF_INSTALL_PLUGINS: redis-datasource
       REDIS_GRAFANA_URL: redis://redis:6379
       REDIS_PASSWORD: ${REDIS_PASSWORD}

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -58,8 +58,6 @@ services:
   grafana:
     image: grafana/grafana:latest
     container_name: sportsify-grafana
-    ports:
-      - "3001:3000"   # 외부 접근 허용 — AWS 보안 그룹에서 3001 포트 제어
     environment:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -53,6 +53,16 @@ http {
             proxy_cache           off;
         }
 
+        # Grafana
+        location /grafana/ {
+            proxy_pass http://sportsify-grafana:3000;
+            proxy_http_version 1.1;
+            include /etc/nginx/proxy_headers.conf;
+            proxy_set_header Connection "";
+            proxy_connect_timeout 5s;
+            proxy_read_timeout    60s;
+        }
+
         # REST API
         location / {
             proxy_pass http://sportsify-active;


### PR DESCRIPTION
 # Related Issues

  -

  ## 작업 리스트

  - [x] nginx `/grafana/` location 추가 (sportsify-grafana:3000 프록시)
  - [x] Grafana sub-path 설정 (`GF_SERVER_SERVE_FROM_SUB_PATH=true`)
  - [x] Grafana 포트 외부 바인딩 (`3001:3000`)
  
  ## 작업 내용
  
`https://api.jhkoder.shop/grafana/` 접근할 수있도록 nginx reverse proxy를 추가
  
* 테스트용으로 바로 배포됨 머지전 필수로 수정 