### PR TITLE
Feat: Add ticketing complete scheduler

### DIFF
--- a/src/main/java/com/sportsify/game/application/scheduler/GameScheduleInitializer.java
+++ b/src/main/java/com/sportsify/game/application/scheduler/GameScheduleInitializer.java
@@ -2,7 +2,7 @@ package com.sportsify.game.application.scheduler;
 
 import com.sportsify.game.domain.model.Game;
 import com.sportsify.game.domain.repository.GameRepository;
-import com.sportsify.ticketing.application.scheduler.OrderExpirationScheduler;
+import com.sportsify.ticketing.application.scheduler.OrderMaintenanceScheduler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -21,7 +21,7 @@ public class GameScheduleInitializer {
     private final GameRepository gameRepository;
     private final GameSaleTaskScheduler gameSaleTaskScheduler;
     private final GameStatusUpdater gameStatusUpdater;
-    private final OrderExpirationScheduler orderExpirationScheduler;
+    private final OrderMaintenanceScheduler orderMaintenanceScheduler;
 
     @EventListener(ApplicationReadyEvent.class)
     @Transactional
@@ -57,7 +57,7 @@ public class GameScheduleInitializer {
         List<Game> onSaleGames = gameRepository.findOnSaleGamesWithFutureSaleEnd(now);
         for (Game game : onSaleGames) {
             gameSaleTaskScheduler.scheduleSaleEnd(game.getId(), game.getSaleEndAt());
-            orderExpirationScheduler.onSaleStarted();
+            orderMaintenanceScheduler.onSaleStarted();
         }
         log.info("[GAME_SCHEDULE_INIT] 판매 종료 예약 등록 - {}건", onSaleGames.size());
     }

--- a/src/main/java/com/sportsify/game/application/scheduler/GameStatusUpdater.java
+++ b/src/main/java/com/sportsify/game/application/scheduler/GameStatusUpdater.java
@@ -5,7 +5,7 @@ import com.sportsify.common.notification.NotificationEventType;
 import com.sportsify.common.notification.payload.TicketOpenPayload;
 import com.sportsify.game.domain.model.GameStatus;
 import com.sportsify.game.domain.repository.GameRepository;
-import com.sportsify.ticketing.application.scheduler.OrderExpirationScheduler;
+import com.sportsify.ticketing.application.scheduler.OrderMaintenanceScheduler;
 import com.sportsify.ticketing.application.service.OrderService;
 import com.sportsify.ticketing.domain.model.OrderConstants;
 import lombok.RequiredArgsConstructor;
@@ -25,13 +25,13 @@ public class GameStatusUpdater {
     private final OrderService orderService;
     private final TaskScheduler gameTaskScheduler;
     private final NotificationEventPublisher notificationEventPublisher;
-    private final OrderExpirationScheduler orderExpirationScheduler;
+    private final OrderMaintenanceScheduler orderMaintenanceScheduler;
 
     public void openSale(Long gameId) {
         gameRepository.findByIdForUpdate(gameId).ifPresent(game -> {
             if (game.getStatus() == GameStatus.SCHEDULED) {
                 game.updateStatus(GameStatus.ON_SALE);
-                orderExpirationScheduler.onSaleStarted();
+                orderMaintenanceScheduler.onSaleStarted();
 
                 notificationEventPublisher.publish(
                         NotificationEventType.TICKET_OPEN,
@@ -48,7 +48,7 @@ public class GameStatusUpdater {
         gameRepository.findByIdForUpdate(gameId).ifPresent(game -> {
             if (game.getStatus() == GameStatus.ON_SALE) {
                 game.updateStatus(GameStatus.SALE_CLOSED);
-                orderExpirationScheduler.onSaleEnded();
+                orderMaintenanceScheduler.onSaleEnded();
 
                 gameTaskScheduler.schedule(() -> {
                     orderService.expireUnpaidOrdersBulk();

--- a/src/main/java/com/sportsify/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/sportsify/infrastructure/config/SecurityConfig.java
@@ -86,6 +86,7 @@ public class SecurityConfig {
                 .exceptionHandling(e -> e.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(publicPaths.toArray(String[]::new)).permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/com/sportsify/ticketing/application/listener/PaymentEventListener.java
+++ b/src/main/java/com/sportsify/ticketing/application/listener/PaymentEventListener.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.resilience.annotation.Retryable;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.CannotCreateTransactionException;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -23,18 +24,26 @@ public class PaymentEventListener {
     private final OrderPaymentService orderPaymentService;
     private final TicketService ticketService;
 
-    @Retryable(maxRetries = 3, delayString = "1000ms")
+    @Retryable(
+            maxRetries = 1,
+            delayString = "500ms",
+            excludes = CannotCreateTransactionException.class
+    )
     @TransactionalEventListener(phase = AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional(propagation = Propagation.REQUIRES_NEW, timeout = 2)
     public void onPaymentSuccess(PaymentCompletedEvent event) {
 
         Order completedOrder = orderPaymentService.completePayment(event);
         ticketService.createTickets(completedOrder);
     }
 
-    @Retryable(maxRetries = 3, delayString = "1000ms")
+    @Retryable(
+            maxRetries = 1,
+            delayString = "500ms",
+            excludes = CannotCreateTransactionException.class
+    )
     @TransactionalEventListener(phase = AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional(propagation = Propagation.REQUIRES_NEW, timeout = 2)
     public void onPaymentCancelled(PaymentCancelledEvent event) {
         orderPaymentService.cancelPayment(event);
     }

--- a/src/main/java/com/sportsify/ticketing/application/processor/OrderSyncProcessor.java
+++ b/src/main/java/com/sportsify/ticketing/application/processor/OrderSyncProcessor.java
@@ -1,0 +1,23 @@
+package com.sportsify.ticketing.application.processor;
+
+import com.sportsify.ticketing.application.service.OrderPaymentService;
+import com.sportsify.ticketing.application.service.TicketService;
+import com.sportsify.ticketing.domain.model.Order;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class OrderSyncProcessor {
+
+    private final OrderPaymentService orderPaymentService;
+    private final TicketService ticketService;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void completeSingleOrder(Long orderId) {
+        Order completedOrder = orderPaymentService.completePayment(orderId);
+        ticketService.createTickets(completedOrder);
+    }
+}

--- a/src/main/java/com/sportsify/ticketing/application/scheduler/OrderMaintenanceScheduler.java
+++ b/src/main/java/com/sportsify/ticketing/application/scheduler/OrderMaintenanceScheduler.java
@@ -11,7 +11,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class OrderExpirationScheduler {
+public class OrderMaintenanceScheduler {
 
     private final OrderService orderService;
     private final AtomicInteger activeSaleCount = new AtomicInteger(0);
@@ -25,7 +25,7 @@ public class OrderExpirationScheduler {
     }
 
     @Scheduled(fixedDelay = 1000)
-    public void releaseUnpaidOrders() {
+    public void processOrderMaintenance() {
         if (activeSaleCount.get() <= 0) {
             return;
         }
@@ -40,6 +40,12 @@ public class OrderExpirationScheduler {
             orderService.cancelFailedPaymentOrdersBulk();
         } catch (RuntimeException e) {
             log.error("[ORDER_SCHEDULER] 결제 실패 건 취소 처리 실패", e);
+        }
+
+        try {
+            orderService.completeStuckOrders();
+        } catch (RuntimeException e) {
+            log.error("[ORDER_SCHEDULER] 결제완료 주문 재처리 실패", e);
         }
     }
 }

--- a/src/main/java/com/sportsify/ticketing/application/service/OrderPaymentService.java
+++ b/src/main/java/com/sportsify/ticketing/application/service/OrderPaymentService.java
@@ -21,13 +21,17 @@ public class OrderPaymentService {
     private final OrderRepository orderRepository;
 
     public Order completePayment(PaymentCompletedEvent event) {
+        return completePayment(event.orderId());
+    }
 
-        Order order = orderRepository.findByIdWithAll(event.orderId())
+    public Order completePayment(Long orderId) {
+
+        Order order = orderRepository.findByIdWithAll(orderId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
         if (order.getStatus() != OrderStatus.PENDING) {
             throw new IllegalStateException(
-                    "결제 완료 불가 상태: orderId=" + event.orderId() + ", status=" + order.getStatus()
+                    "결제 완료 불가 상태: orderId=" + orderId + ", status=" + order.getStatus()
             );
         }
 

--- a/src/main/java/com/sportsify/ticketing/application/service/OrderService.java
+++ b/src/main/java/com/sportsify/ticketing/application/service/OrderService.java
@@ -1,6 +1,7 @@
 package com.sportsify.ticketing.application.service;
 
 import com.sportsify.game.domain.repository.GameSeatRepository;
+import com.sportsify.ticketing.domain.model.Order;
 import com.sportsify.ticketing.domain.model.OrderSeatStatus;
 import com.sportsify.ticketing.domain.model.OrderStatus;
 import com.sportsify.ticketing.domain.repository.OrderRepository;
@@ -18,10 +19,10 @@ import java.util.List;
 @Slf4j
 public class OrderService {
     private final OrderRepository orderRepository;
-
     private final OrderSeatRepository orderSeatRepository;
-
     private final GameSeatRepository gameSeatRepository;
+    private final OrderPaymentService orderPaymentService;
+    private final TicketService ticketService;
 
     @Transactional
     public void expireUnpaidOrdersBulk() {
@@ -44,6 +45,15 @@ public class OrderService {
         log.info("[ORDER_SCHEDULER] Failed Bulk size: {}", orderIds.size());
 
         releaseSeatsBulk(orderIds, now, OrderSeatStatus.CANCELLED, OrderStatus.CANCELLED);
+    }
+
+    @Transactional
+    public void completeStuckOrders() {
+        orderRepository.findPendingOrderIdsWithCompletedPayment().forEach(orderId -> {
+            Order completedOrder = orderPaymentService.completePayment(orderId);
+            ticketService.createTickets(completedOrder);
+        });
+
     }
 
     public void releaseSeatsBulk(List<Long> orderIds, LocalDateTime now, OrderSeatStatus orderSeatstatus, OrderStatus orderStatus) {

--- a/src/main/java/com/sportsify/ticketing/application/service/OrderService.java
+++ b/src/main/java/com/sportsify/ticketing/application/service/OrderService.java
@@ -1,7 +1,7 @@
 package com.sportsify.ticketing.application.service;
 
 import com.sportsify.game.domain.repository.GameSeatRepository;
-import com.sportsify.ticketing.domain.model.Order;
+import com.sportsify.ticketing.application.processor.OrderSyncProcessor;
 import com.sportsify.ticketing.domain.model.OrderSeatStatus;
 import com.sportsify.ticketing.domain.model.OrderStatus;
 import com.sportsify.ticketing.domain.repository.OrderRepository;
@@ -21,8 +21,7 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final OrderSeatRepository orderSeatRepository;
     private final GameSeatRepository gameSeatRepository;
-    private final OrderPaymentService orderPaymentService;
-    private final TicketService ticketService;
+    private final OrderSyncProcessor orderSyncProcessor;
 
     @Transactional
     public void expireUnpaidOrdersBulk() {
@@ -48,12 +47,25 @@ public class OrderService {
     }
 
     @Transactional
-    public void completeStuckOrders() {
-        orderRepository.findPendingOrderIdsWithCompletedPayment().forEach(orderId -> {
-            Order completedOrder = orderPaymentService.completePayment(orderId);
-            ticketService.createTickets(completedOrder);
-        });
+    public int completeStuckOrders() {
+        List<Long> orderIds = orderRepository.findPendingOrderIdsWithCompletedPayment();
 
+        if (orderIds.isEmpty()) return 0;
+
+        int successSync = orderIds.size();
+
+        for (Long orderId : orderIds) {
+            try {
+                orderSyncProcessor.completeSingleOrder(orderId);
+            } catch (RuntimeException e) {
+                log.error("[ORDER_SCHEDULER_SYNC_FAIL] 주문 ID {} 재처리 중 에러 발생 - 패스하고 다음 건 진행", orderId, e);
+                successSync--;
+            }
+        }
+
+        log.info("[ORDER_SCHEDULER] Sync complete size: {}", successSync);
+
+        return successSync;
     }
 
     public void releaseSeatsBulk(List<Long> orderIds, LocalDateTime now, OrderSeatStatus orderSeatstatus, OrderStatus orderStatus) {

--- a/src/main/java/com/sportsify/ticketing/domain/repository/OrderRepository.java
+++ b/src/main/java/com/sportsify/ticketing/domain/repository/OrderRepository.java
@@ -21,6 +21,8 @@ public interface OrderRepository {
 
     List<Long> findPendingOrderIdsWithFailedPayment();
 
+    List<Long> findPendingOrderIdsWithCompletedPayment();
+
     void bulkUpdateOrders(@Param("ids") List<Long> ids, @Param("status") OrderStatus status, @Param("now") LocalDateTime now);
 
     Optional<Order> findByIdWithAll(Long id);

--- a/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderJpaRepository.java
+++ b/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderJpaRepository.java
@@ -22,6 +22,7 @@ public interface OrderJpaRepository extends JpaRepository<Order, Long> {
             JOIN FETCH o.member
             WHERE o.id = :orderId
             """)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Order> findByIdWithAll(@Param("orderId") Long orderId);
 
     @Query(value = """
@@ -45,6 +46,15 @@ public interface OrderJpaRepository extends JpaRepository<Order, Long> {
             """
     )
     List<Long> findPendingOrderIdsWithFailedPayment();
+
+
+    @Query("""
+                SELECT o.id FROM Order o
+                JOIN Payment p ON p.orderId = o.id
+                WHERE p.status = "COMPLETED" AND o.status = "PENDING"
+            """)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<Long> findPendingOrderIdsWithCompletedPayment();
 
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderJpaRepository.java
+++ b/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderJpaRepository.java
@@ -62,10 +62,11 @@ public interface OrderJpaRepository extends JpaRepository<Order, Long> {
     Optional<Order> findByIdWithLock(@Param("id") Long id);
 
     @Query("""
-                SELECT DISTINCT gs.id FROM Order o
-                JOIN o.orderSeats os
+                SELECT DISTINCT g.id
+                FROM OrderSeat os
                 JOIN os.gameSeat gs
-                WHERE o.id = :orderId
+                JOIN gs.game g
+                WHERE os.order.id = :orderId
             """)
     Long findGameIdByOrderId(@Param("orderId") Long orderId);
 

--- a/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderJpaRepository.java
+++ b/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderJpaRepository.java
@@ -49,9 +49,13 @@ public interface OrderJpaRepository extends JpaRepository<Order, Long> {
 
 
     @Query("""
-                SELECT o.id FROM Order o
-                JOIN Payment p ON p.orderId = o.id
-                WHERE p.status = "COMPLETED" AND o.status = "PENDING"
+            SELECT o.id FROM Order o
+             WHERE o.status = 'PENDING'
+             AND EXISTS (
+                 SELECT p FROM Payment p
+                 WHERE p.orderId = o.id
+                 AND p.status = 'COMPLETED'
+             )
             """)
     List<Long> findPendingOrderIdsWithCompletedPayment();
 

--- a/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderJpaRepository.java
+++ b/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderJpaRepository.java
@@ -53,7 +53,6 @@ public interface OrderJpaRepository extends JpaRepository<Order, Long> {
                 JOIN Payment p ON p.orderId = o.id
                 WHERE p.status = "COMPLETED" AND o.status = "PENDING"
             """)
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     List<Long> findPendingOrderIdsWithCompletedPayment();
 
 

--- a/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderRepositoryAdapter.java
+++ b/src/main/java/com/sportsify/ticketing/infrastructure/repository/OrderRepositoryAdapter.java
@@ -53,6 +53,11 @@ public class OrderRepositoryAdapter implements OrderRepository {
     }
 
     @Override
+    public List<Long> findPendingOrderIdsWithCompletedPayment() {
+        return jpaRepository.findPendingOrderIdsWithCompletedPayment();
+    }
+
+    @Override
     public void bulkUpdateOrders(List<Long> ids, OrderStatus status, LocalDateTime now) {
         jpaRepository.bulkUpdateOrders(ids, status, now);
     }

--- a/src/main/java/com/sportsify/ticketing/presentation/controller/OrderAdminController.java
+++ b/src/main/java/com/sportsify/ticketing/presentation/controller/OrderAdminController.java
@@ -1,0 +1,24 @@
+package com.sportsify.ticketing.presentation.controller;
+
+import com.sportsify.ticketing.application.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/orders")
+@RequiredArgsConstructor
+public class OrderAdminController {
+    private final OrderService orderService;
+
+    @PostMapping("/complete-sync")
+    public ResponseEntity<String> SyncCompleteStuckOrders(
+            @AuthenticationPrincipal Long memberId
+    ) {
+        int successCount = orderService.completeStuckOrders();
+        return ResponseEntity.ok(String.format("수동 처리가 완료되었습니다. (성공: %d건)", successCount));
+    }
+}

--- a/src/main/java/com/sportsify/ticketing/presentation/controller/OrderAdminController.java
+++ b/src/main/java/com/sportsify/ticketing/presentation/controller/OrderAdminController.java
@@ -15,7 +15,7 @@ public class OrderAdminController {
     private final OrderService orderService;
 
     @PostMapping("/complete-sync")
-    public ResponseEntity<String> SyncCompleteStuckOrders(
+    public ResponseEntity<String> syncCompleteStuckOrders(
             @AuthenticationPrincipal Long memberId
     ) {
         int successCount = orderService.completeStuckOrders();

--- a/src/test/java/com/sportsify/game/application/GameScheduleInitializerTest.java
+++ b/src/test/java/com/sportsify/game/application/GameScheduleInitializerTest.java
@@ -5,7 +5,7 @@ import com.sportsify.game.application.scheduler.GameScheduleInitializer;
 import com.sportsify.game.application.scheduler.GameStatusUpdater;
 import com.sportsify.game.domain.model.Game;
 import com.sportsify.game.domain.repository.GameRepository;
-import com.sportsify.ticketing.application.scheduler.OrderExpirationScheduler;
+import com.sportsify.ticketing.application.scheduler.OrderMaintenanceScheduler;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,7 +35,7 @@ class GameScheduleInitializerTest {
     private GameStatusUpdater gameStatusUpdater;
 
     @Mock
-    private OrderExpirationScheduler orderExpirationScheduler;
+    private OrderMaintenanceScheduler orderMaintenanceScheduler;
 
     @Test
     @DisplayName("서버 시작 시 saleStartAt이 지난 SCHEDULED 경기를 즉시 ON_SALE로 전환한다.")
@@ -106,6 +106,6 @@ class GameScheduleInitializerTest {
         gameScheduleInitializer.init();
 
         verify(gameSaleTaskScheduler).scheduleSaleEnd(1L, saleEndAt);
-        verify(orderExpirationScheduler).onSaleStarted();
+        verify(orderMaintenanceScheduler).onSaleStarted();
     }
 }

--- a/src/test/java/com/sportsify/game/application/GameServiceTest.java
+++ b/src/test/java/com/sportsify/game/application/GameServiceTest.java
@@ -15,7 +15,6 @@ import com.sportsify.game.presentation.dto.GameCreateResponseDto;
 import com.sportsify.team.domain.model.SportType;
 import com.sportsify.team.domain.model.Team;
 import com.sportsify.team.domain.repository.TeamRepository;
-import com.sportsify.ticketing.application.scheduler.OrderExpirationScheduler;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,10 +50,6 @@ class GameServiceTest {
 
     @Mock
     private GameSaleTaskScheduler gameSaleTaskScheduler;
-
-    @Mock
-    private OrderExpirationScheduler orderExpirationScheduler;
-
 
     @Test
     @DisplayName("경기 생성 성공")

--- a/src/test/java/com/sportsify/game/application/GameStatusUpdaterTest.java
+++ b/src/test/java/com/sportsify/game/application/GameStatusUpdaterTest.java
@@ -7,7 +7,7 @@ import com.sportsify.game.application.scheduler.GameStatusUpdater;
 import com.sportsify.game.domain.model.Game;
 import com.sportsify.game.domain.model.GameStatus;
 import com.sportsify.game.domain.repository.GameRepository;
-import com.sportsify.ticketing.application.scheduler.OrderExpirationScheduler;
+import com.sportsify.ticketing.application.scheduler.OrderMaintenanceScheduler;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,7 +35,7 @@ class GameStatusUpdaterTest {
     private NotificationEventPublisher notificationEventPublisher;
 
     @Mock
-    private OrderExpirationScheduler orderExpirationScheduler;
+    private OrderMaintenanceScheduler orderMaintenanceScheduler;
 
     @Mock
     private TaskScheduler gameTaskScheduler;
@@ -49,7 +49,7 @@ class GameStatusUpdaterTest {
 
         gameStatusUpdater.openSale(1L);
 
-        verify(orderExpirationScheduler).onSaleStarted();
+        verify(orderMaintenanceScheduler).onSaleStarted();
         verify(game).updateStatus(GameStatus.ON_SALE);
         verify(notificationEventPublisher).publish(eq(NotificationEventType.TICKET_OPEN), any(TicketOpenPayload.class));
     }
@@ -85,7 +85,7 @@ class GameStatusUpdaterTest {
 
         gameStatusUpdater.closeSale(1L);
 
-        verify(orderExpirationScheduler).onSaleEnded();
+        verify(orderMaintenanceScheduler).onSaleEnded();
         verify(gameTaskScheduler).schedule(any(Runnable.class), any(Instant.class));
         verify(game).updateStatus(GameStatus.SALE_CLOSED);
     }

--- a/src/test/java/com/sportsify/ticketing/application/OrderMaintenanceSchedulerTest.java
+++ b/src/test/java/com/sportsify/ticketing/application/OrderMaintenanceSchedulerTest.java
@@ -156,39 +156,43 @@ public class OrderMaintenanceSchedulerTest extends RepositoryTestSupport {
 
     @Test
     @DisplayName("결제완료면서 미처리된 주문의 좌석이 Confirmed되고 티켓이 생성된다.")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     void pendingOrderWithConfirmedPayment_confirmsOrderAndSeat_createTickets() {
-        Long memberId = fixture.createMember("t2@test.com", "n2").getId();
-        List<Long> gameSeatIds = fixture.createGameSeatsWithCount(game, 2);
+        Long orderId = transactionTemplate.execute(tx -> {
+            Long memberId = fixture.createMember("t2@test.com", "n2").getId();
+            List<Long> gameSeatIds = fixture.createGameSeatsWithCount(game, 2);
+            ReservationSeatsRequestDto reqDto = new ReservationSeatsRequestDto(game.getId(), gameSeatIds);
+            ReservationSeatsResponseDto resDto = reservationService.reserveSeat(memberId, reqDto);
+            Order order = orderRepository.findById(resDto.orderId()).orElseThrow();
 
-        ReservationSeatsRequestDto reqDto = new ReservationSeatsRequestDto(game.getId(), gameSeatIds);
-        ReservationSeatsResponseDto resDto = reservationService.reserveSeat(memberId, reqDto);
-        Order order = orderRepository.findById(resDto.orderId()).orElseThrow();
+            Payment payment = Payment.builder()
+                    .userId(member.getId())
+                    .matchId(game.getId())
+                    .seatId(gameSeatIds.get(0))
+                    .orderId(order.getId())
+                    .tossOrderId("TEST_TOSS_ORDER_" + order.getId())
+                    .idempotencyKey("TEST_IDEMPOTENCY_" + order.getId())
+                    .amount(order.getTotalAmount())
+                    .paymentMethod("PAY")
+                    .status(PaymentStatus.COMPLETED)
+                    .requestedAt(LocalDateTime.now())
+                    .build();
 
-        Payment payment = Payment.builder()
-                .userId(member.getId())
-                .matchId(game.getId())
-                .seatId(gameSeatIds.get(0))
-                .orderId(order.getId())
-                .tossOrderId("TEST_TOSS_ORDER_" + order.getId())
-                .idempotencyKey("TEST_IDEMPOTENCY_" + order.getId())
-                .amount(order.getTotalAmount())
-                .paymentMethod("PAY")
-                .status(PaymentStatus.COMPLETED)
-                .requestedAt(LocalDateTime.now())
-                .build();
-
-        paymentRepository.save(payment);
-        Long orderId = order.getId();
+            paymentRepository.save(payment);
+            return order.getId();
+        });
 
         scheduler.processOrderMaintenance();
 
-        Order updatedOrder = orderRepository.findById(orderId).orElseThrow();
-        assertThat(updatedOrder.getStatus()).isEqualTo(OrderStatus.CONFIRMED);
-        Pageable pageable = PageRequest.of(0, 10, Sort.by("id").descending());
+        transactionTemplate.executeWithoutResult(tx -> {
+            Order updatedOrder = orderRepository.findById(orderId).orElseThrow();
+            assertThat(updatedOrder.getStatus()).isEqualTo(OrderStatus.CONFIRMED);
+            Pageable pageable = PageRequest.of(0, 10, Sort.by("id").descending());
 
-        Page<Ticket> tickets = ticketRepository.findByMemberId(updatedOrder.getMemberId(), pageable);
-        assertThat(tickets.get()).hasSize(updatedOrder.getOrderSeats().size());
-        assertThat(tickets.get().allMatch(ticket -> ticket.getStatus() == TicketStatus.CONFIRMED)).isTrue();
+            Page<Ticket> tickets = ticketRepository.findByMemberId(updatedOrder.getMemberId(), pageable);
+            assertThat(tickets.get()).hasSize(updatedOrder.getOrderSeats().size());
+            assertThat(tickets.get().allMatch(ticket -> ticket.getStatus() == TicketStatus.CONFIRMED)).isTrue();
+        });
     }
 
 

--- a/src/test/java/com/sportsify/ticketing/application/OrderMaintenanceSchedulerTest.java
+++ b/src/test/java/com/sportsify/ticketing/application/OrderMaintenanceSchedulerTest.java
@@ -9,13 +9,11 @@ import com.sportsify.payment.domain.entity.Payment;
 import com.sportsify.payment.domain.repository.PaymentRepository;
 import com.sportsify.payment.domain.type.PaymentStatus;
 import com.sportsify.support.RepositoryTestSupport;
-import com.sportsify.ticketing.application.scheduler.OrderExpirationScheduler;
+import com.sportsify.ticketing.application.scheduler.OrderMaintenanceScheduler;
 import com.sportsify.ticketing.application.service.ReservationService;
-import com.sportsify.ticketing.domain.model.Order;
-import com.sportsify.ticketing.domain.model.OrderSeat;
-import com.sportsify.ticketing.domain.model.OrderSeatStatus;
-import com.sportsify.ticketing.domain.model.OrderStatus;
+import com.sportsify.ticketing.domain.model.*;
 import com.sportsify.ticketing.domain.repository.OrderRepository;
+import com.sportsify.ticketing.domain.repository.TicketRepository;
 import com.sportsify.ticketing.fixture.TicketingTestFixture;
 import com.sportsify.ticketing.presentation.dto.ReservationSeatsRequestDto;
 import com.sportsify.ticketing.presentation.dto.ReservationSeatsResponseDto;
@@ -28,6 +26,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -43,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
-public class OrderExpirationSchedulerTest extends RepositoryTestSupport {
+public class OrderMaintenanceSchedulerTest extends RepositoryTestSupport {
     private Member member;
     private Game game;
 
@@ -57,10 +59,13 @@ public class OrderExpirationSchedulerTest extends RepositoryTestSupport {
     private GameSeatRepository gameSeatRepository;
 
     @Autowired
+    private TicketRepository ticketRepository;
+
+    @Autowired
     private ReservationService reservationService;
 
     @Autowired
-    private OrderExpirationScheduler scheduler;
+    private OrderMaintenanceScheduler scheduler;
 
     @Autowired
     private TicketingTestFixture fixture;
@@ -83,86 +88,113 @@ public class OrderExpirationSchedulerTest extends RepositoryTestSupport {
 
     @Test
     @DisplayName("만료된 주문의 좌석이 AVAILABLE로 복구된다")
-    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     void expiredOrder_seatBecomesAvailable() {
-        Long orderId = transactionTemplate.execute(txStatus -> {
-            List<Long> gameSeatIds = fixture.createGameSeatsWithCount(game, 2);
+        List<Long> gameSeatIds = fixture.createGameSeatsWithCount(game, 2);
 
-            ReservationSeatsRequestDto reqDto = new ReservationSeatsRequestDto(game.getId(), gameSeatIds);
-            ReservationSeatsResponseDto resDto = reservationService.reserveSeat(member.getId(), reqDto);
-            Order order = orderRepository.findById(resDto.orderId()).orElseThrow();
+        ReservationSeatsRequestDto reqDto = new ReservationSeatsRequestDto(game.getId(), gameSeatIds);
+        ReservationSeatsResponseDto resDto = reservationService.reserveSeat(member.getId(), reqDto);
+        Order order = orderRepository.findById(resDto.orderId()).orElseThrow();
 
-            order.updateExpiresAt(LocalDateTime.now().minusMinutes(1));
-            return orderRepository.save(order).getId();
-        });
+        order.updateExpiresAt(LocalDateTime.now().minusMinutes(1));
+        Long orderId = orderRepository.save(order).getId();
 
-        scheduler.releaseUnpaidOrders();
+        scheduler.processOrderMaintenance();
 
-        transactionTemplate.executeWithoutResult(txStatus -> {
-            Order savedOrder = orderRepository.findByIdWithAll(orderId).orElseThrow();
-            List<OrderSeat> orderSeats = savedOrder.getOrderSeats();
+        Order updatedOrder = orderRepository.findByIdWithAll(orderId).orElseThrow();
+        List<OrderSeat> orderSeats = updatedOrder.getOrderSeats();
 
-            assertThat(savedOrder.getStatus()).isEqualTo(OrderStatus.EXPIRED);
-            assertThat(orderSeats)
-                    .extracting(OrderSeat::getStatus)
-                    .containsOnly(OrderSeatStatus.EXPIRED);
-            assertThat(orderSeats)
-                    .extracting(OrderSeat::getGameSeat)
-                    .extracting(GameSeat::getSeatStatus)
-                    .containsOnly(SeatStatus.AVAILABLE);
-        });
+        assertThat(updatedOrder.getStatus()).isEqualTo(OrderStatus.EXPIRED);
+        assertThat(orderSeats)
+                .extracting(OrderSeat::getStatus)
+                .containsOnly(OrderSeatStatus.EXPIRED);
+        assertThat(orderSeats)
+                .extracting(OrderSeat::getGameSeat)
+                .extracting(GameSeat::getSeatStatus)
+                .containsOnly(SeatStatus.AVAILABLE);
     }
 
     @ParameterizedTest
-    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     @DisplayName("결제 실패/취소/환불한 주문의 좌석이 AVAILABLE로 복구된다")
     @EnumSource(value = PaymentStatus.class, names = {"FAILED", "CANCELED", "REFUNDED"})
-    void payingOrderWithFailedPayment_seatBecomesAvailable(PaymentStatus status) {
-        Long orderId = transactionTemplate.execute(txStatus -> {
-            List<Long> gameSeatIds = fixture.createGameSeatsWithCount(game, 2);
+    void pendingOrderWithFailedPayment_seatBecomesAvailable(PaymentStatus status) {
+        List<Long> gameSeatIds = fixture.createGameSeatsWithCount(game, 2);
 
-            ReservationSeatsRequestDto reqDto = new ReservationSeatsRequestDto(game.getId(), gameSeatIds);
-            ReservationSeatsResponseDto resDto = reservationService.reserveSeat(member.getId(), reqDto);
-            Order order = orderRepository.findById(resDto.orderId()).orElseThrow();
+        ReservationSeatsRequestDto reqDto = new ReservationSeatsRequestDto(game.getId(), gameSeatIds);
+        ReservationSeatsResponseDto resDto = reservationService.reserveSeat(member.getId(), reqDto);
+        Order order = orderRepository.findById(resDto.orderId()).orElseThrow();
 
-            Payment payment = Payment.builder()
-                    .userId(member.getId())
-                    .matchId(game.getId())
-                    .seatId(gameSeatIds.get(0))
-                    .orderId(order.getId())
-                    .tossOrderId("TEST_TOSS_ORDER_" + order.getId())
-                    .idempotencyKey("TEST_IDEMPOTENCY_" + order.getId())
-                    .amount(order.getTotalAmount())
-                    .paymentMethod("PAY")
-                    .status(status)
-                    .requestedAt(LocalDateTime.now())
-                    .build();
+        Payment payment = Payment.builder()
+                .userId(member.getId())
+                .matchId(game.getId())
+                .seatId(gameSeatIds.get(0))
+                .orderId(order.getId())
+                .tossOrderId("TEST_TOSS_ORDER_" + order.getId())
+                .idempotencyKey("TEST_IDEMPOTENCY_" + order.getId())
+                .amount(order.getTotalAmount())
+                .paymentMethod("PAY")
+                .status(status)
+                .requestedAt(LocalDateTime.now())
+                .build();
 
-            paymentRepository.save(payment);
-            return order.getId();
-        });
+        paymentRepository.save(payment);
+        Long orderId = order.getId();
 
-        scheduler.releaseUnpaidOrders();
+        scheduler.processOrderMaintenance();
 
-        transactionTemplate.executeWithoutResult(txStatus -> {
-            Order savedOrder = orderRepository.findByIdWithAll(orderId).orElseThrow();
-            List<OrderSeat> orderSeats = savedOrder.getOrderSeats();
+        Order updatedOrder = orderRepository.findByIdWithAll(orderId).orElseThrow();
+        List<OrderSeat> orderSeats = updatedOrder.getOrderSeats();
 
-            assertThat(savedOrder.getStatus()).isEqualTo(OrderStatus.CANCELLED);
-            assertThat(orderSeats)
-                    .extracting(OrderSeat::getStatus)
-                    .containsOnly(OrderSeatStatus.CANCELLED);
-            assertThat(orderSeats)
-                    .extracting(OrderSeat::getGameSeat)
-                    .extracting(GameSeat::getSeatStatus)
-                    .containsOnly(SeatStatus.AVAILABLE);
-        });
+        assertThat(updatedOrder.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+        assertThat(orderSeats)
+                .extracting(OrderSeat::getStatus)
+                .containsOnly(OrderSeatStatus.CANCELLED);
+        assertThat(orderSeats)
+                .extracting(OrderSeat::getGameSeat)
+                .extracting(GameSeat::getSeatStatus)
+                .containsOnly(SeatStatus.AVAILABLE);
+    }
+
+    @Test
+    @DisplayName("결제완료면서 미처리된 주문의 좌석이 Confirmed되고 티켓이 생성된다.")
+    void pendingOrderWithConfirmedPayment_confirmsOrderAndSeat_createTickets() {
+        Long memberId = fixture.createMember("t2@test.com", "n2").getId();
+        List<Long> gameSeatIds = fixture.createGameSeatsWithCount(game, 2);
+
+        ReservationSeatsRequestDto reqDto = new ReservationSeatsRequestDto(game.getId(), gameSeatIds);
+        ReservationSeatsResponseDto resDto = reservationService.reserveSeat(memberId, reqDto);
+        Order order = orderRepository.findById(resDto.orderId()).orElseThrow();
+
+        Payment payment = Payment.builder()
+                .userId(member.getId())
+                .matchId(game.getId())
+                .seatId(gameSeatIds.get(0))
+                .orderId(order.getId())
+                .tossOrderId("TEST_TOSS_ORDER_" + order.getId())
+                .idempotencyKey("TEST_IDEMPOTENCY_" + order.getId())
+                .amount(order.getTotalAmount())
+                .paymentMethod("PAY")
+                .status(PaymentStatus.COMPLETED)
+                .requestedAt(LocalDateTime.now())
+                .build();
+
+        paymentRepository.save(payment);
+        Long orderId = order.getId();
+
+        scheduler.processOrderMaintenance();
+
+        Order updatedOrder = orderRepository.findById(orderId).orElseThrow();
+        assertThat(updatedOrder.getStatus()).isEqualTo(OrderStatus.CONFIRMED);
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("id").descending());
+
+        Page<Ticket> tickets = ticketRepository.findByMemberId(updatedOrder.getMemberId(), pageable);
+        assertThat(tickets.get()).hasSize(updatedOrder.getOrderSeats().size());
+        assertThat(tickets.get().allMatch(ticket -> ticket.getStatus() == TicketStatus.CONFIRMED)).isTrue();
     }
 
 
     @ParameterizedTest
     @ValueSource(ints = {3, 5, 8})
-    @DisplayName("동시성 테스트: 결제가 락 보유 중이면 스케줄러는 SKIP LOCKED로 PendingOrder의 해당 행을 건너뛴다.")
+    @DisplayName("결제가 락 보유 중이면 스케줄러는 SKIP LOCKED로 PendingOrder의 해당 행을 건너뛴다.")
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     void paymentLocksFirst_schedulerSkips(int skipCount) throws InterruptedException {
         List<Long> skipIds = new ArrayList<>();

--- a/src/test/java/com/sportsify/ticketing/application/OrderMaintenanceSchedulerUnitTest.java
+++ b/src/test/java/com/sportsify/ticketing/application/OrderMaintenanceSchedulerUnitTest.java
@@ -1,6 +1,6 @@
 package com.sportsify.ticketing.application;
 
-import com.sportsify.ticketing.application.scheduler.OrderExpirationScheduler;
+import com.sportsify.ticketing.application.scheduler.OrderMaintenanceScheduler;
 import com.sportsify.ticketing.application.service.OrderService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,10 +17,10 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(OutputCaptureExtension.class)
-class OrderExpirationSchedulerUnitTest {
+class OrderMaintenanceSchedulerUnitTest {
 
     @InjectMocks
-    private OrderExpirationScheduler scheduler;
+    private OrderMaintenanceScheduler scheduler;
 
     @Mock
     private OrderService orderService;
@@ -31,10 +31,11 @@ class OrderExpirationSchedulerUnitTest {
     void schedulerSkipsWhenNoActiveSale() {
         scheduler.onSaleStarted();
         scheduler.onSaleEnded();
-        scheduler.releaseUnpaidOrders();
+        scheduler.processOrderMaintenance();
 
         verify(orderService, never()).expireUnpaidOrdersBulk();
         verify(orderService, never()).cancelFailedPaymentOrdersBulk();
+        verify(orderService, never()).completeStuckOrders();
     }
 
     @Test
@@ -42,21 +43,22 @@ class OrderExpirationSchedulerUnitTest {
     void schedulerRunsWhenSaleActive() {
         scheduler.onSaleStarted();
 
-        scheduler.releaseUnpaidOrders();
+        scheduler.processOrderMaintenance();
 
         verify(orderService).expireUnpaidOrdersBulk();
         verify(orderService).cancelFailedPaymentOrdersBulk();
+        verify(orderService).completeStuckOrders();
     }
 
     @Test
-    @DisplayName("미결제 만료 처리에서 오류가 발생하면 예외를 삼키고 로그만 남긴다.")
+    @DisplayName("미결제 만료 처리에서 오류가 발생하면 로그를 남기고 예외를 삼킨다")
     void expireUnpaidOrders_catchesException(CapturedOutput output) {
         scheduler.onSaleStarted();
 
         doThrow(new RuntimeException("DB 에러"))
                 .when(orderService).expireUnpaidOrdersBulk();
 
-        assertThatCode(() -> scheduler.releaseUnpaidOrders())
+        assertThatCode(() -> scheduler.processOrderMaintenance())
                 .doesNotThrowAnyException();
 
         assertThat(output.getOut()).contains("[ORDER_SCHEDULER] 미결제 만료 처리 실패");
@@ -65,14 +67,14 @@ class OrderExpirationSchedulerUnitTest {
     }
 
     @Test
-    @DisplayName("결제 실패 취소 처리에서 오류가 발생해도 예외를 삼킨다")
+    @DisplayName("결제 실패 취소 처리에서 오류가 발생해면 로그를 남기고 예외를 삼킨다")
     void cancelFailedPayment_catchesException(CapturedOutput output) {
         scheduler.onSaleStarted();
 
         doThrow(new RuntimeException("DB 에러"))
                 .when(orderService).cancelFailedPaymentOrdersBulk();
 
-        assertThatCode(() -> scheduler.releaseUnpaidOrders())
+        assertThatCode(() -> scheduler.processOrderMaintenance())
                 .doesNotThrowAnyException();
 
         assertThat(output.getOut()).contains("[ORDER_SCHEDULER] 결제 실패 건 취소 처리 실패");
@@ -80,19 +82,37 @@ class OrderExpirationSchedulerUnitTest {
     }
 
     @Test
-    @DisplayName("둘 다 실패해도 예외를 삼킨다")
+    @DisplayName("결제완료 주문 재처리에서 오류가 발생하면 로그를 남기고 예외를 삼킨다")
+    void completeStuckOrders_catchesException(CapturedOutput output) {
+        scheduler.onSaleStarted();
+
+        doThrow(new RuntimeException())
+                .when(orderService).completeStuckOrders();
+
+        assertThatCode(() -> scheduler.processOrderMaintenance())
+                .doesNotThrowAnyException();
+
+        assertThat(output.getOut()).contains("[ORDER_SCHEDULER] 결제완료 주문 재처리 실패");
+        verify(orderService).completeStuckOrders();
+    }
+
+    @Test
+    @DisplayName("모두 다 실패해도 예외를 삼킨다")
     void bothFail_catchesException(CapturedOutput output) {
         scheduler.onSaleStarted();
-        
+
         doThrow(new RuntimeException("expire 에러"))
                 .when(orderService).expireUnpaidOrdersBulk();
         doThrow(new RuntimeException("cancel 에러"))
                 .when(orderService).cancelFailedPaymentOrdersBulk();
+        doThrow(new RuntimeException("complete 에러"))
+                .when(orderService).completeStuckOrders();
 
-        assertThatCode(() -> scheduler.releaseUnpaidOrders())
+        assertThatCode(() -> scheduler.processOrderMaintenance())
                 .doesNotThrowAnyException();
 
         assertThat(output.getOut()).contains("[ORDER_SCHEDULER] 미결제 만료 처리 실패");
         assertThat(output.getOut()).contains("[ORDER_SCHEDULER] 결제 실패 건 취소 처리 실패");
+        assertThat(output.getOut()).contains("[ORDER_SCHEDULER] 결제완료 주문 재처리 실패");
     }
 }

--- a/src/test/java/com/sportsify/ticketing/application/OrderServiceTest.java
+++ b/src/test/java/com/sportsify/ticketing/application/OrderServiceTest.java
@@ -1,6 +1,7 @@
 package com.sportsify.ticketing.application;
 
 import com.sportsify.game.domain.repository.GameSeatRepository;
+import com.sportsify.ticketing.application.processor.OrderSyncProcessor;
 import com.sportsify.ticketing.application.service.OrderService;
 import com.sportsify.ticketing.domain.model.OrderSeatStatus;
 import com.sportsify.ticketing.domain.model.OrderStatus;
@@ -35,6 +36,8 @@ class OrderServiceTest {
     private OrderSeatRepository orderSeatRepository;
     @Mock
     private GameSeatRepository gameSeatRepository;
+    @Mock
+    private OrderSyncProcessor orderSyncProcessor;
 
     @Test
     @DisplayName("만료된 주문이 없을 때 그대로 return한다.")
@@ -79,6 +82,33 @@ class OrderServiceTest {
         verify(gameSeatRepository).bulkReleaseGameSeatsByOrderIds(anyList());
         verify(orderSeatRepository).bulkUpdateOrderSeats(anyList(), any());
         verify(orderRepository).bulkUpdateOrders(anyList(), any(), any());
+    }
+
+    @Test
+    @DisplayName("완료 미처리된 주문들이 있을 때 각각 완료 처리가 진행된다.")
+    void success_completeStuckOrders(CapturedOutput output) {
+        List<Long> stuckOrders = List.of(1L, 2L);
+        when(orderRepository.findPendingOrderIdsWithCompletedPayment()).thenReturn(stuckOrders);
+
+        int successCount = orderService.completeStuckOrders();
+
+        verify(orderSyncProcessor, times(stuckOrders.size())).completeSingleOrder(anyLong());
+        assertThat(output.getOut()).contains("[ORDER_SCHEDULER] Sync complete size: " + stuckOrders.size());
+        assertThat(successCount).isEqualTo(stuckOrders.size());
+    }
+
+    @Test
+    @DisplayName("완료 재처리 주문 중, 실패한 건은 그대로 넘어간다.")
+    void successAndErrorLog_completeStuckOrders(CapturedOutput output) {
+        List<Long> stuckOrders = List.of(1L, 2L);
+        when(orderRepository.findPendingOrderIdsWithCompletedPayment()).thenReturn(stuckOrders);
+        doNothing().when(orderSyncProcessor).completeSingleOrder(stuckOrders.getFirst());
+        doThrow(new RuntimeException("fail")).when(orderSyncProcessor).completeSingleOrder(stuckOrders.getLast());
+
+        int successCount = orderService.completeStuckOrders();
+
+        assertThat(output.getOut()).contains("[ORDER_SCHEDULER_SYNC_FAIL] 주문 ID " + stuckOrders.getLast());
+        assertThat(successCount).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/com/sportsify/ticketing/application/PaymentEventListenerTest.java
+++ b/src/test/java/com/sportsify/ticketing/application/PaymentEventListenerTest.java
@@ -15,6 +15,8 @@ import com.sportsify.ticketing.fixture.TicketingTestFixture;
 import com.sportsify.ticketing.infrastructure.repository.OrderJpaRepository;
 import com.sportsify.ticketing.infrastructure.repository.TicketJpaRepository;
 import com.sportsify.ticketing.presentation.dto.ReservationSeatsRequestDto;
+import com.zaxxer.hikari.HikariDataSource;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,7 +33,15 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,6 +50,7 @@ import static org.awaitility.Awaitility.await;
 
 @EnableAsync
 @ExtendWith(OutputCaptureExtension.class)
+@Slf4j
 class PaymentEventListenerTest extends RepositoryTestSupport {
 
     @Autowired
@@ -66,6 +77,8 @@ class PaymentEventListenerTest extends RepositoryTestSupport {
     @Autowired
     private PaymentEventListener paymentEventListener;
 
+    @Autowired
+    private DataSource dataSource;
 
     private Member member;
     private Game game;
@@ -112,76 +125,124 @@ class PaymentEventListenerTest extends RepositoryTestSupport {
             eventPublisher.publishEvent(eventFixture.createCompletedEventByOrderId(orderId, member.getId()));
         });
 
-        await().atMost(5, TimeUnit.SECONDS)
-                .untilAsserted(() -> {
-                    Order result = orderRepository.findById(orderId).orElseThrow();
+        Order result = orderRepository.findById(orderId).orElseThrow();
 
-                    assertThat(result.getExpiresAt()).isNotNull();
-                    assertThat(output.getOut()).contains("결제 완료 불가 상태");
-                });
+        assertThat(result.getExpiresAt()).isNotNull();
+        assertThat(output.getOut()).contains("결제 완료 불가 상태");
     }
 
     @Test
-    @DisplayName("결제 완료 이벤트 수신 시, 주문과 좌석이 확정된다.")
+    @DisplayName("결제 완료 이벤트 수신 시, 주문과 좌석이 확정되고 티켓이 생성된다.")
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    void onSuccessPaymentEvent() {
+    void onSuccessPaymentEvent_success() {
         ReservationSeatsRequestDto reqDto = new ReservationSeatsRequestDto(game.getId(), gameSeatIds);
         Long orderId = reservationService.reserveSeat(member.getId(), reqDto).orderId();
 
         transactionTemplate.executeWithoutResult(s -> {
             eventPublisher.publishEvent(eventFixture.createCompletedEventByOrderId(orderId, member.getId()));
         });
+        transactionTemplate.executeWithoutResult(s -> {
+            List<Ticket> tickets = ticketRepository.findAll();
+            Order updatedOrder = orderRepository.findById(orderId).orElseThrow();
+            List<Long> orderSeatIds = updatedOrder.getOrderSeats().stream().map(OrderSeat::getId).toList();
 
-        await().atMost(5, TimeUnit.SECONDS)
-                .untilAsserted(() -> {
-                    transactionTemplate.executeWithoutResult(status -> {
-                        Order updatedOrder = orderRepository.findById(orderId).orElseThrow();
-                        assertThat(updatedOrder.getStatus()).isEqualTo(OrderStatus.CONFIRMED);
-                        assertThat(updatedOrder.getExpiresAt()).isNull();
+            assertThat(updatedOrder.getStatus()).isEqualTo(OrderStatus.CONFIRMED);
+            assertThat(updatedOrder.getExpiresAt()).isNull();
 
-                        assertThat(updatedOrder.getOrderSeats())
-                                .extracting(OrderSeat::getStatus)
-                                .containsOnly(OrderSeatStatus.CONFIRMED);
+            assertThat(updatedOrder.getOrderSeats())
+                    .extracting(OrderSeat::getStatus)
+                    .containsOnly(OrderSeatStatus.CONFIRMED);
 
-                        assertThat(updatedOrder.getOrderSeats())
-                                .extracting(OrderSeat::getGameSeat)
-                                .extracting(GameSeat::getSeatStatus)
-                                .containsOnly(SeatStatus.SOLD);
-                    });
-                });
+            assertThat(updatedOrder.getOrderSeats())
+                    .extracting(OrderSeat::getGameSeat)
+                    .extracting(GameSeat::getSeatStatus)
+                    .containsOnly(SeatStatus.SOLD);
+
+            assertThat(tickets).hasSize(gameSeatIds.size());
+            assertThat(tickets)
+                    .extracting(ticket -> ticket.getOrderSeat().getId())
+                    .containsExactlyInAnyOrderElementsOf(orderSeatIds);
+
+            assertThat(tickets)
+                    .extracting(Ticket::getStatus)
+                    .containsOnly(TicketStatus.CONFIRMED);
+        });
     }
 
-
     @Test
-    @DisplayName("결제 완료 이벤트 수신 시, 좌석별 티켓이 생성된다.")
+    @DisplayName("결제 완료 이벤트 수신 시, 풀 고갈이면 5초 이내로 실패한다.")
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    void onSuccessPaymentEvent_createTickets() {
+    void onSuccessPaymentEvent_poolExhaustionFails_within5s() throws SQLException {
         ReservationSeatsRequestDto reqDto = new ReservationSeatsRequestDto(game.getId(), gameSeatIds);
         Long orderId = reservationService.reserveSeat(member.getId(), reqDto).orderId();
 
-        transactionTemplate.executeWithoutResult(s -> {
-            eventPublisher.publishEvent(eventFixture.createCompletedEventByOrderId(orderId, member.getId()));
+        HikariDataSource hikariDS = (HikariDataSource) dataSource;
+        List<Connection> held = new ArrayList<>();
+        for (int i = 0; i < hikariDS.getMaximumPoolSize(); i++) {
+            held.add(hikariDS.getConnection());
+        }
+
+        long start = System.currentTimeMillis();
+        try {
+            paymentEventListener.onPaymentSuccess(eventFixture.createCompletedEventByOrderId(orderId, member.getId()));
+        } catch (Exception e) {
+            long elapsed = System.currentTimeMillis() - start;
+            assertThat(elapsed).isBetween(4_000L, 6_000L);
+        } finally {
+            held.forEach(c -> {
+                try {
+                    c.close();
+                } catch (Exception ignored) {
+                }
+            });
+        }
+    }
+
+    @Test
+    @DisplayName("결제 완료 이벤트 수신 시, 락 대기가 발생하면 트랜잭션 타임아웃으로 5초 이내 실패한다.")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void onSuccessPaymentEvent_lockContention_under5s() throws Exception {
+        ReservationSeatsRequestDto reqDto = new ReservationSeatsRequestDto(game.getId(), gameSeatIds);
+        Long orderId = reservationService.reserveSeat(member.getId(), reqDto).orderId();
+
+        HikariDataSource hikariDS = (HikariDataSource) dataSource;
+        CountDownLatch lockAcquired = new CountDownLatch(1);
+        CountDownLatch testDone = new CountDownLatch(1);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        executor.submit(() -> {
+            try (Connection conn = hikariDS.getConnection()) {
+                conn.setAutoCommit(false);
+                try (PreparedStatement stmt = conn.prepareStatement(
+                        "SELECT * FROM orders WHERE id = ? FOR UPDATE")) {
+                    stmt.setLong(1, orderId);
+                    stmt.executeQuery();
+                    lockAcquired.countDown();
+
+                    testDone.await(30, TimeUnit.SECONDS);
+                }
+                conn.rollback();
+            } catch (Exception e) {
+                log.error("락 스레드 에러", e);
+            }
         });
 
+        boolean acquired = lockAcquired.await(5, TimeUnit.SECONDS);
+        assertThat(acquired).isTrue();
 
-        await().atMost(5, TimeUnit.SECONDS)
-                .untilAsserted(() -> {
-                    transactionTemplate.executeWithoutResult(status -> {
-                        List<Ticket> tickets = ticketRepository.findAll();
-                        Order order = orderRepository.findById(orderId).orElseThrow();
-                        List<Long> orderSeatIds = order.getOrderSeats().stream().map(OrderSeat::getId).toList();
-                        assertThat(tickets).hasSize(gameSeatIds.size());
-                        assertThat(tickets)
-                                .extracting(ticket -> ticket.getOrderSeat().getId())
-                                .containsExactlyInAnyOrderElementsOf(orderSeatIds);
+        long start = System.currentTimeMillis();
 
-                        assertThat(tickets)
-                                .extracting(ticket -> ticket.getStatus())
-                                .containsOnly(TicketStatus.CONFIRMED);
+        try {
+            paymentEventListener.onPaymentSuccess(eventFixture.createCompletedEventByOrderId(orderId, member.getId()));
+        } catch (Exception e) {
+            long elapsed = System.currentTimeMillis() - start;
 
-                    });
-                });
-
+            assertThat(elapsed).isLessThan(5_000);
+        } finally {
+            testDone.countDown();
+            executor.shutdown();
+            executor.awaitTermination(5, TimeUnit.SECONDS);
+        }
     }
 
     @Test

--- a/src/test/java/com/sportsify/ticketing/infrastructure/OrderRepositoryTest.java
+++ b/src/test/java/com/sportsify/ticketing/infrastructure/OrderRepositoryTest.java
@@ -1,0 +1,49 @@
+package com.sportsify.ticketing.infrastructure;
+
+
+import com.sportsify.game.domain.model.Game;
+import com.sportsify.game.domain.model.GameSeat;
+import com.sportsify.game.domain.repository.GameSeatRepository;
+import com.sportsify.support.RepositoryTestSupport;
+import com.sportsify.ticketing.domain.model.Order;
+import com.sportsify.ticketing.domain.model.OrderSeat;
+import com.sportsify.ticketing.domain.repository.OrderRepository;
+import com.sportsify.ticketing.fixture.TicketingTestFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OrderRepositoryTest extends RepositoryTestSupport {
+
+    @Autowired
+    private OrderRepository orderRepository;
+    @Autowired
+    private GameSeatRepository gameSeatRepository;
+
+    @Autowired
+    private TicketingTestFixture fixture;
+
+    @BeforeEach
+    void beforeEach() {
+        fixture.deleteAll();
+    }
+
+    @Test
+    @DisplayName("주문과 관련된 게임ID를 반환한다.")
+    void findGameIdByOrderId() {
+        Game game = fixture.createGame();
+        Order order = Order.create(fixture.createMember("t1@test.com", "n1"));
+        GameSeat gameSeat = gameSeatRepository
+                .findById(fixture.createGameSeatsWithCount(game, 1).getFirst())
+                .orElseThrow();
+        order.addOrderSeat(OrderSeat.create(order, gameSeat, gameSeat.getPrice()));
+        order.calculateTotalAmount();
+        orderRepository.save(order);
+
+        Long gameIdByOrderId = orderRepository.findGameIdByOrderId(order.getId());
+        assertThat(gameIdByOrderId).isEqualTo(game.getId());
+    }
+}

--- a/src/test/java/com/sportsify/ticketing/presentation/OrderAdminControllerApiTest.java
+++ b/src/test/java/com/sportsify/ticketing/presentation/OrderAdminControllerApiTest.java
@@ -1,0 +1,42 @@
+package com.sportsify.ticketing.presentation;
+
+import com.sportsify.support.WebMvcTestSupport;
+import com.sportsify.ticketing.application.service.OrderService;
+import com.sportsify.ticketing.presentation.controller.OrderAdminController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(OrderAdminController.class)
+class OrderAdminControllerApiTest extends WebMvcTestSupport {
+    private static final Long TEST_MEMBER_ID = 1L;
+    @MockitoBean
+    private OrderService orderService;
+
+
+    @Test
+    @DisplayName("POST /api/admin/orders/complete-sync — 200 미완료 주문건 재처리 성공")
+    void admin_completeStuckOrders_success() throws Exception {
+        when(orderService.completeStuckOrders()).thenReturn(1);
+
+        mockMvc.perform(post("/api/admin/orders/complete-sync")
+                        .header("Authorization", bearerToken(TEST_MEMBER_ID, "ADMIN")))
+                .andExpect(status().isOk())
+                .andExpect(content().string("수동 처리가 완료되었습니다. (성공: 1건)"));
+
+    }
+
+    @Test
+    @DisplayName("POST /api/admin/orders/complete-sync — 403 admin이 아닌 일반 유저는 실패")
+    public void notAllowNormalUser_fails() throws Exception {
+        mockMvc.perform(post("/api/admin/orders/complete-sync")
+                        .header("Authorization", bearerToken(TEST_MEMBER_ID, "USER")))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
# Related Issues

- #69

## 작업 리스트
- payment-order 트랜잭션 전파 문제 검토
- order 트랜잭션 응답속도 10초 제한 적용
- complete 실패 시 재처리 로직 추가

## 작업 내용
### payment-order 트랜잭션 전파 문제 검토
- 이벤트 리스너: After commit 후 order 트랜잭션 시작 → 500 error 전파 X, order측 커밋까지 클라이언트 응답 대기 O
- 응답속도: 10초 제한으로 리팩토링
  - 풀 고갈 시 최대 5초 대기 후 종료: HikariCP 풀 고갈 타임아웃 5초 + Retry 스킵
  - 트랜잭션 오류 시(락 대기 등) 최대 4.5초 대기 후 종료: Transaction 타임아웃 2초 + Retry 1번(2초) + delay 0.5초
  - 테스트코드로 확인 완료

### complete 실패 시 재처리 로직 추가
- OrderMaintenanceScheduler에 적용(예매 시에만 활성)
  - 주문=Pending, 결제=Completed 건 조회 → 주문/좌석 확정 & 티켓 생성
  - 단위/통합 테스트 추가
-  티켓 중복 생성 방지: findByWithAll에 FOR UPDATE Lock 설정
- 미처리된 주문&티켓생성 보완용 관리자 API 추가
  - SecurityConfig: 'api/admin/**' 추가로 접근권한 관리
- 다건 롤백 방지용 Processor 설정
  - 오류 건만 스킵

### 리팩토링
- 스케줄러 이름 변경: `OrderExpirationScheduler` → `OrderMaintenanceScheduler`
- completePayment: 이벤트 리스너 + 스케줄러 동작하도록 오버로딩 메서드 추가
- 단위/통합 테스트 내 비동기용 코드 삭제(NOT_SUPPORTED, transactionTemplate)

### 테스트 및 이슈 해결
- jacoco coverage 100% 유지
- gameId가 아닌 gameSeatId 반환했던 query 수정

## 참고사항
1. 티켓 생성 시의 알림이 필요할지 논의 필요
  - 결제 성공 & 티켓생성 실패 시 유저가 알 수 없음(1초 후 스케줄러가 동작해서 해결하긴 함)
  - 티켓 생성 알림으로 보완 가능